### PR TITLE
Fix to handle empty first-line in HTTP Response

### DIFF
--- a/Titanium.Web.Proxy/Http/HttpWebClient.cs
+++ b/Titanium.Web.Proxy/Http/HttpWebClient.cs
@@ -115,8 +115,10 @@ namespace Titanium.Web.Proxy.Http
 
             if (string.IsNullOrEmpty(httpResult[0]))
             {
-                await ServerConnection.StreamReader.ReadLineAsync();
+                //Empty content in first-line, try again
+                httpResult = (await ServerConnection.StreamReader.ReadLineAsync()).Split(ProxyConstants.SpaceSplit, 3);
             }
+
             var httpVersion = httpResult[0].Trim().ToLower();
 
             var version = new Version(1,1);


### PR DESCRIPTION
When the first line read in the HTTP response is empty, read thenext line into httpResult.
Fixes bug where next line was read but httpResult was not updated