### PR TITLE
Get makecert.exe path in a way that also works with Resharper tests

### DIFF
--- a/Titanium.Web.Proxy/Network/CertificateManager.cs
+++ b/Titanium.Web.Proxy/Network/CertificateManager.cs
@@ -167,7 +167,7 @@ namespace Titanium.Web.Proxy.Network
 
             var process = new Process();
 
-            string file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "makecert.exe");
+            string file = Path.Combine(Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath), "makecert.exe");
 
             if (!File.Exists(file))
             {


### PR DESCRIPTION
Resharper shadow-copies the binaries to another location (normally a folder inside the current user's Temp folder) (see http://stackoverflow.com/a/25672385/835351).
This makes the current code not work because ``Assembly.GetExecutingAssembly().Location`` returns this specific path which only contains the test application's dll and pdb files, but none of the other contents.
This is a fix that works in all the cases: for applications and tests, with or without Resharper