### PR TITLE
IP Helper API wrapped to associate port with process id

### DIFF
--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -115,6 +115,9 @@ namespace Titanium.Web.Proxy.Examples.Basic
             //read response headers
             var responseHeaders = e.WebSession.Response.ResponseHeaders;
 
+            // print out process id of current session
+            Console.WriteLine($"PID: {e.WebSession.ProcessId}");
+
             //if (!e.ProxySession.Request.Host.Equals("medeczane.sgk.gov.tr")) return;
             if (e.WebSession.Request.Method == "GET" || e.WebSession.Request.Method == "POST")
             {

--- a/Titanium.Web.Proxy/Helpers/SystemProxy.cs
+++ b/Titanium.Web.Proxy/Helpers/SystemProxy.cs
@@ -11,7 +11,7 @@ using System.Linq;
 namespace Titanium.Web.Proxy.Helpers
 {
   
-    internal  class NativeMethods
+    internal partial class NativeMethods
     {
         [DllImport("wininet.dll")]
         internal static extern bool InternetSetOption(IntPtr hInternet, int dwOption, IntPtr lpBuffer,

--- a/Titanium.Web.Proxy/Helpers/Tcp.cs
+++ b/Titanium.Web.Proxy/Helpers/Tcp.cs
@@ -2,20 +2,116 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
 using Titanium.Web.Proxy.Extensions;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Network;
+using Titanium.Web.Proxy.Tcp;
 
 namespace Titanium.Web.Proxy.Helpers
 {
+    internal partial class NativeMethods
+    {
+        internal const int AfInet = 2;
+
+        internal enum TcpTableType
+        {
+            BasicListener,
+            BasicConnections,
+            BasicAll,
+            OwnerPidListener,
+            OwnerPidConnections,
+            OwnerPidAll,
+            OwnerModuleListener,
+            OwnerModuleConnections,
+            OwnerModuleAll,
+        }
+
+        /// <summary>
+        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366921.aspx"/>
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TcpTable
+        {
+            public uint length;
+            public TcpRow row;
+        }
+
+        /// <summary>
+        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TcpRow
+        {
+            public TcpState state;
+            public uint localAddr;
+            public byte localPort1;
+            public byte localPort2;
+            public byte localPort3;
+            public byte localPort4;
+            public uint remoteAddr;
+            public byte remotePort1;
+            public byte remotePort2;
+            public byte remotePort3;
+            public byte remotePort4;
+            public int owningPid;
+        }
+
+        /// <summary>
+        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa365928.aspx"/>
+        /// </summary>
+        [DllImport("iphlpapi.dll", SetLastError = true)]
+        internal static extern uint GetExtendedTcpTable(IntPtr tcpTable, ref int size, bool sort, int ipVersion, int tableClass, int reserved);
+    }
 
     internal class TcpHelper
     {
+        /// <summary>
+        /// Gets the extended TCP table.
+        /// </summary>
+        /// <returns>Collection of <see cref="TcpRow"/>.</returns>
+        internal static TcpTable GetExtendedTcpTable()
+        {
+            List<TcpRow> tcpRows = new List<TcpRow>();
+
+            IntPtr tcpTable = IntPtr.Zero;
+            int tcpTableLength = 0;
+
+            if (NativeMethods.GetExtendedTcpTable(tcpTable, ref tcpTableLength, false, NativeMethods.AfInet, (int)NativeMethods.TcpTableType.OwnerPidAll, 0) != 0)
+            {
+                try
+                {
+                    tcpTable = Marshal.AllocHGlobal(tcpTableLength);
+                    if (NativeMethods.GetExtendedTcpTable(tcpTable, ref tcpTableLength, true, NativeMethods.AfInet, (int)NativeMethods.TcpTableType.OwnerPidAll, 0) == 0)
+                    {
+                        NativeMethods.TcpTable table = (NativeMethods.TcpTable)Marshal.PtrToStructure(tcpTable, typeof(NativeMethods.TcpTable));
+
+                        IntPtr rowPtr = (IntPtr)((long)tcpTable + Marshal.SizeOf(table.length));
+
+                        for (int i = 0; i < table.length; ++i)
+                        {
+                            tcpRows.Add(new TcpRow((NativeMethods.TcpRow)Marshal.PtrToStructure(rowPtr, typeof(NativeMethods.TcpRow))));
+                            rowPtr = (IntPtr)((long)rowPtr + Marshal.SizeOf(typeof(NativeMethods.TcpRow)));
+                        }
+                    }
+                }
+                finally
+                {
+                    if (tcpTable != IntPtr.Zero)
+                    {
+                        Marshal.FreeHGlobal(tcpTable);
+                    }
+                }
+            }
+
+            return new TcpTable(tcpRows);
+        }
 
         /// <summary>
         /// relays the input clientStream to the server at the specified host name & port with the given httpCmd & headers as prefix
@@ -103,6 +199,5 @@ namespace Titanium.Web.Proxy.Helpers
                 tcpConnection.Dispose();
             }
         }
-
     }
 }

--- a/Titanium.Web.Proxy/Http/HttpWebClient.cs
+++ b/Titanium.Web.Proxy/Http/HttpWebClient.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Titanium.Web.Proxy.Helpers;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Network;
 using Titanium.Web.Proxy.Shared;
+using Titanium.Web.Proxy.Tcp;
 
 namespace Titanium.Web.Proxy.Http
 {
@@ -14,6 +17,8 @@ namespace Titanium.Web.Proxy.Http
     /// </summary>
     public class HttpWebClient
     {
+        private int processId;
+
         /// <summary>
         /// Connection to server
         /// </summary>
@@ -21,6 +26,24 @@ namespace Titanium.Web.Proxy.Http
 
         public Request Request { get; set; }
         public Response Response { get; set; }
+
+        /// <summary>
+        /// PID of the process that is created the current session
+        /// </summary>
+        public int ProcessId
+        {
+            get
+            {
+                if (processId == 0)
+                {
+                    TcpRow tcpRow = TcpHelper.GetExtendedTcpTable().TcpRows.FirstOrDefault(row => row.LocalEndPoint.Port == ServerConnection.port);
+
+                    processId = tcpRow?.ProcessId ?? -1;
+                }
+
+                return processId;
+            }
+        }
 
         /// <summary>
         /// Is Https?

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -116,6 +116,11 @@ namespace Titanium.Web.Proxy
         public SslProtocols SupportedSslProtocols { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Ssl3;
 
         /// <summary>
+        /// Is the proxy currently running
+        /// </summary>
+        public bool ProxyRunning => proxyRunning;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         public ProxyServer()

--- a/Titanium.Web.Proxy/Tcp/TcpRow.cs
+++ b/Titanium.Web.Proxy/Tcp/TcpRow.cs
@@ -1,0 +1,35 @@
+﻿using System.Net;
+using Titanium.Web.Proxy.Helpers;
+
+namespace Titanium.Web.Proxy.Tcp
+{
+    /// <summary>
+    /// Represents a managed interface of IP Helper API TcpRow struct
+    /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
+    /// </summary>
+    internal class TcpRow
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpRow"/> class.
+        /// </summary>
+        /// <param name="tcpRow">TcpRow struct.</param>
+        public TcpRow(NativeMethods.TcpRow tcpRow)
+        {
+            ProcessId = tcpRow.owningPid;
+
+            int localPort = (tcpRow.localPort1 << 8) + (tcpRow.localPort2) + (tcpRow.localPort3 << 24) + (tcpRow.localPort4 << 16);
+            long localAddress = tcpRow.localAddr;
+            LocalEndPoint = new IPEndPoint(localAddress, localPort);
+        }
+
+        /// <summary>
+        /// Gets the local end point.
+        /// </summary>
+        public IPEndPoint LocalEndPoint { get; private set; }
+
+        /// <summary>
+        /// Gets the process identifier.
+        /// </summary>
+        public int ProcessId { get; private set; }
+    }
+}

--- a/Titanium.Web.Proxy/Tcp/TcpTable.cs
+++ b/Titanium.Web.Proxy/Tcp/TcpTable.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Titanium.Web.Proxy.Tcp
+{
+    /// <summary>
+    /// Represents collection of TcpRows
+    /// </summary>
+    /// <seealso cref="System.Collections.Generic.IEnumerable{Titanium.Web.Proxy.Tcp.TcpRow}" />
+    internal class TcpTable : IEnumerable<TcpRow>
+    {
+        private readonly IEnumerable<TcpRow> tcpRows;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpTable"/> class.
+        /// </summary>
+        /// <param name="tcpRows">TcpRow collection to initialize with.</param>
+        public TcpTable(IEnumerable<TcpRow> tcpRows)
+        {
+            this.tcpRows = tcpRows;
+        }
+
+        /// <summary>
+        /// Gets the TCP rows.
+        /// </summary>
+        public IEnumerable<TcpRow> TcpRows => tcpRows;
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<TcpRow> GetEnumerator()
+        {
+            return tcpRows.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -92,6 +92,8 @@
     <Compile Include="Http\Responses\OkResponse.cs" />
     <Compile Include="Http\Responses\RedirectResponse.cs" />
     <Compile Include="Shared\ProxyConstants.cs" />
+    <Compile Include="Tcp\TcpRow.cs" />
+    <Compile Include="Tcp\TcpTable.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>


### PR DESCRIPTION
* ProxyRunning property is added to ProxyServer class.
* IP Helper API 'GetExtendedTcpTable' method and relevant structures are wrapped.
* ProcessId property is added to HttpWebClient class.