### PR TITLE
IP Helper API wrapped to associate port with process id

### DIFF
--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -115,6 +115,9 @@ namespace Titanium.Web.Proxy.Examples.Basic
             //read response headers
             var responseHeaders = e.WebSession.Response.ResponseHeaders;
 
+            // print out process id of current session
+            Console.WriteLine($"PID: {e.WebSession.ProcessId}");
+
             //if (!e.ProxySession.Request.Host.Equals("medeczane.sgk.gov.tr")) return;
             if (e.WebSession.Request.Method == "GET" || e.WebSession.Request.Method == "POST")
             {

--- a/Titanium.Web.Proxy/Extensions/StreamExtensions.cs
+++ b/Titanium.Web.Proxy/Extensions/StreamExtensions.cs
@@ -29,27 +29,20 @@ namespace Titanium.Web.Proxy.Extensions
 
             await input.CopyToAsync(output);
         }
-        /// <summary>
-        /// copies the specified bytes to the stream from the input stream
-        /// </summary>
-        /// <param name="streamReader"></param>
-        /// <param name="stream"></param>
-        /// <param name="totalBytesToRead"></param>
-        /// <returns></returns>
-        internal static async Task CopyBytesToStream(this CustomBinaryReader streamReader, int bufferSize, Stream stream, long totalBytesToRead)
+
+	    /// <summary>
+	    /// copies the specified bytes to the stream from the input stream
+	    /// </summary>
+	    /// <param name="streamReader"></param>
+	    /// <param name="bufferSize"></param>
+	    /// <param name="stream"></param>
+	    /// <param name="totalBytesToRead"></param>
+	    /// <returns></returns>
+	    internal static async Task CopyBytesToStream(this CustomBinaryReader streamReader, int bufferSize, Stream stream, long totalBytesToRead)
         {
             var totalbytesRead = 0;
 
-            long bytesToRead;
-            if (totalBytesToRead < bufferSize)
-            {
-                bytesToRead = totalBytesToRead;
-            }
-            else
-            {
-                bytesToRead = bufferSize;
-            }
-
+            long bytesToRead = totalBytesToRead < bufferSize ? totalBytesToRead : bufferSize;
 
             while (totalbytesRead < totalBytesToRead)
             {
@@ -72,13 +65,14 @@ namespace Titanium.Web.Proxy.Extensions
             }
         }
 
-        /// <summary>
-        /// Copies the stream chunked
-        /// </summary>
-        /// <param name="clientStreamReader"></param>
-        /// <param name="stream"></param>
-        /// <returns></returns>
-        internal static async Task CopyBytesToStreamChunked(this CustomBinaryReader clientStreamReader, int bufferSize, Stream stream)
+	    /// <summary>
+	    /// Copies the stream chunked
+	    /// </summary>
+	    /// <param name="clientStreamReader"></param>
+	    /// <param name="bufferSize"></param>
+	    /// <param name="stream"></param>
+	    /// <returns></returns>
+	    internal static async Task CopyBytesToStreamChunked(this CustomBinaryReader clientStreamReader, int bufferSize, Stream stream)
         {
             while (true)
             {
@@ -117,30 +111,32 @@ namespace Titanium.Web.Proxy.Extensions
                 await WriteResponseBodyChunked(data, clientStream);
             }
         }
-        /// <summary>
-        /// Copies the specified content length number of bytes to the output stream from the given inputs stream
-        /// optionally chunked
-        /// </summary>
-        /// <param name="inStreamReader"></param>
-        /// <param name="outStream"></param>
-        /// <param name="isChunked"></param>
-        /// <param name="ContentLength"></param>
-        /// <returns></returns>
-        internal static async Task WriteResponseBody(this CustomBinaryReader inStreamReader, int bufferSize, Stream outStream, bool isChunked, long ContentLength)
+
+	    /// <summary>
+	    /// Copies the specified content length number of bytes to the output stream from the given inputs stream
+	    /// optionally chunked
+	    /// </summary>
+	    /// <param name="inStreamReader"></param>
+	    /// <param name="bufferSize"></param>
+	    /// <param name="outStream"></param>
+	    /// <param name="isChunked"></param>
+	    /// <param name="contentLength"></param>
+	    /// <returns></returns>
+	    internal static async Task WriteResponseBody(this CustomBinaryReader inStreamReader, int bufferSize, Stream outStream, bool isChunked, long contentLength)
         {
             if (!isChunked)
             {
                 //http 1.0
-                if (ContentLength == -1)
+                if (contentLength == -1)
                 {
-                    ContentLength = long.MaxValue;
+                    contentLength = long.MaxValue;
                 }
 
                 int bytesToRead = bufferSize;
 
-                if (ContentLength < bufferSize)
+                if (contentLength < bufferSize)
                 {
-                    bytesToRead = (int)ContentLength;
+                    bytesToRead = (int)contentLength;
                 }
 
                 var buffer = new byte[bufferSize];
@@ -153,11 +149,11 @@ namespace Titanium.Web.Proxy.Extensions
                     await outStream.WriteAsync(buffer, 0, bytesRead);
                     totalBytesRead += bytesRead;
 
-                    if (totalBytesRead == ContentLength)
+                    if (totalBytesRead == contentLength)
                         break;
 
                     bytesRead = 0;
-                    var remainingBytes = (ContentLength - totalBytesRead);
+                    var remainingBytes = (contentLength - totalBytesRead);
                     bytesToRead = remainingBytes > (long)bufferSize ? bufferSize : (int)remainingBytes;
                 }
             }
@@ -167,13 +163,14 @@ namespace Titanium.Web.Proxy.Extensions
             }
         }
 
-        /// <summary>
-        /// Copies the streams chunked
-        /// </summary>
-        /// <param name="inStreamReader"></param>
-        /// <param name="outStream"></param>
-        /// <returns></returns>
-        internal static async Task WriteResponseBodyChunked(this CustomBinaryReader inStreamReader, int bufferSize, Stream outStream)
+	    /// <summary>
+	    /// Copies the streams chunked
+	    /// </summary>
+	    /// <param name="inStreamReader"></param>
+	    /// <param name="bufferSize"></param>
+	    /// <param name="outStream"></param>
+	    /// <returns></returns>
+	    internal static async Task WriteResponseBodyChunked(this CustomBinaryReader inStreamReader, int bufferSize, Stream outStream)
         {
             while (true)
             {

--- a/Titanium.Web.Proxy/Helpers/CustomBinaryReader.cs
+++ b/Titanium.Web.Proxy/Helpers/CustomBinaryReader.cs
@@ -37,37 +37,30 @@ namespace Titanium.Web.Proxy.Helpers
         {
             using (var readBuffer = new MemoryStream())
             {
-                try
-                {
-                    var lastChar = default(char);
-                    var buffer = new byte[1];
+	            var lastChar = default(char);
+	            var buffer = new byte[1];
 
-                    while ((await this.stream.ReadAsync(buffer, 0, 1)) > 0)
-                    {
-                        //if new line
-                        if (lastChar == '\r' && buffer[0] == '\n')
-                        {
-                            var result = readBuffer.ToArray();
-                            return  encoding.GetString(result.SubArray(0, result.Length - 1));
-                        }
-                        //end of stream
-                        if (buffer[0] == '\0')
-                        {
-                            return encoding.GetString(readBuffer.ToArray());
-                        }
+	            while ((await this.stream.ReadAsync(buffer, 0, 1)) > 0)
+	            {
+		            //if new line
+		            if (lastChar == '\r' && buffer[0] == '\n')
+		            {
+			            var result = readBuffer.ToArray();
+			            return  encoding.GetString(result.SubArray(0, result.Length - 1));
+		            }
+		            //end of stream
+		            if (buffer[0] == '\0')
+		            {
+			            return encoding.GetString(readBuffer.ToArray());
+		            }
 
-                        await readBuffer.WriteAsync(buffer,0,1);
+		            await readBuffer.WriteAsync(buffer,0,1);
 
-                        //store last char for new line comparison
-                        lastChar = (char)buffer[0];
-                    }
+		            //store last char for new line comparison
+		            lastChar = (char)buffer[0];
+	            }
 
-                    return encoding.GetString(readBuffer.ToArray());
-                }
-                catch (IOException)
-                {
-                    throw;
-                }
+	            return encoding.GetString(readBuffer.ToArray());
             }
         }
 

--- a/Titanium.Web.Proxy/Helpers/SystemProxy.cs
+++ b/Titanium.Web.Proxy/Helpers/SystemProxy.cs
@@ -11,7 +11,7 @@ using System.Linq;
 namespace Titanium.Web.Proxy.Helpers
 {
   
-    internal  class NativeMethods
+    internal partial class NativeMethods
     {
         [DllImport("wininet.dll")]
         internal static extern bool InternetSetOption(IntPtr hInternet, int dwOption, IntPtr lpBuffer,

--- a/Titanium.Web.Proxy/Helpers/SystemProxy.cs
+++ b/Titanium.Web.Proxy/Helpers/SystemProxy.cs
@@ -4,13 +4,19 @@ using Microsoft.Win32;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 
 /// <summary>
 /// Helper classes for setting system proxy settings
 /// </summary>
 namespace Titanium.Web.Proxy.Helpers
 {
-  
+    internal enum ProxyProtocolType
+    {
+        Http,
+        Https,
+    }
+
     internal partial class NativeMethods
     {
         [DllImport("wininet.dll")]
@@ -26,16 +32,10 @@ namespace Titanium.Web.Proxy.Helpers
 
         public override string ToString()
         {
-            if (!IsHttps)
-            {
-                return "http=" + HostName + ":" + Port;
-            }
-            else
-            {
-                return "https=" + HostName + ":" + Port;
-            }
+            return $"{(IsHttps ? "https" : "http")}={HostName}:{Port}";
         }
     }
+
     /// <summary>
     /// Manage system proxy settings
     /// </summary>
@@ -44,62 +44,17 @@ namespace Titanium.Web.Proxy.Helpers
         internal const int InternetOptionSettingsChanged = 39;
         internal const int InternetOptionRefresh = 37;
 
-        internal  void SetHttpProxy(string hostname, int port)
+        internal void SetHttpProxy(string hostname, int port)
         {
-            var reg = Registry.CurrentUser.OpenSubKey(
-                "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
-
-            if (reg != null)
-            {
-                prepareRegistry(reg);
-
-                var exisitingContent = reg.GetValue("ProxyServer") as string;
-                var existingSystemProxyValues = GetSystemProxyValues(exisitingContent);
-                existingSystemProxyValues.RemoveAll(x => !x.IsHttps);
-                existingSystemProxyValues.Add(new HttpSystemProxyValue()
-                {
-                    HostName = hostname,
-                    IsHttps = false,
-                    Port = port
-                });
-
-                reg.SetValue("ProxyEnable", 1);
-                reg.SetValue("ProxyServer", String.Join(";", existingSystemProxyValues.Select(x => x.ToString()).ToArray()));
-            }
-
-            Refresh();
+            SetProxy(hostname, port, ProxyProtocolType.Http);
         }
 
         /// <summary>
         /// Remove the http proxy setting from current machine
         /// </summary>
-        internal  void RemoveHttpProxy()
+        internal void RemoveHttpProxy()
         {
-            var reg = Registry.CurrentUser.OpenSubKey(
-                    "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
-            if (reg != null)
-            {
-                if (reg.GetValue("ProxyServer") != null)
-                {
-                    var exisitingContent = reg.GetValue("ProxyServer") as string;
-
-                    var existingSystemProxyValues = GetSystemProxyValues(exisitingContent);
-                    existingSystemProxyValues.RemoveAll(x => !x.IsHttps);
-
-                    if (!(existingSystemProxyValues.Count() == 0))
-                    {
-                        reg.SetValue("ProxyEnable", 1);
-                        reg.SetValue("ProxyServer", String.Join(";", existingSystemProxyValues.Select(x => x.ToString()).ToArray()));
-                    }
-                    else
-                    {
-                        reg.SetValue("ProxyEnable", 0);
-                        reg.SetValue("ProxyServer", string.Empty);
-                    }
-                }
-            }
-
-            Refresh();
+            RemoveProxy(ProxyProtocolType.Http);
         }
 
         /// <summary>
@@ -107,60 +62,65 @@ namespace Titanium.Web.Proxy.Helpers
         /// </summary>
         /// <param name="hostname"></param>
         /// <param name="port"></param>
-        internal  void SetHttpsProxy(string hostname, int port)
+        internal void SetHttpsProxy(string hostname, int port)
+        {
+            SetProxy(hostname, port, ProxyProtocolType.Https);
+        }
+
+        /// <summary>
+        /// Removes the https proxy setting to nothing
+        /// </summary>
+        internal void RemoveHttpsProxy()
+        {
+            RemoveProxy(ProxyProtocolType.Https);
+        }
+
+        private void SetProxy(string hostname, int port, ProxyProtocolType protocolType)
         {
             var reg = Registry.CurrentUser.OpenSubKey(
                 "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
 
             if (reg != null)
             {
-                prepareRegistry(reg);
+                PrepareRegistry(reg);
 
                 var exisitingContent = reg.GetValue("ProxyServer") as string;
-
                 var existingSystemProxyValues = GetSystemProxyValues(exisitingContent);
-                existingSystemProxyValues.RemoveAll(x => x.IsHttps);
+                existingSystemProxyValues.RemoveAll(x => protocolType == ProxyProtocolType.Https ? x.IsHttps : !x.IsHttps);
                 existingSystemProxyValues.Add(new HttpSystemProxyValue()
                 {
                     HostName = hostname,
-                    IsHttps = true,
+                    IsHttps = protocolType == ProxyProtocolType.Https,
                     Port = port
                 });
 
                 reg.SetValue("ProxyEnable", 1);
-                reg.SetValue("ProxyServer", String.Join(";", existingSystemProxyValues.Select(x => x.ToString()).ToArray()));
+                reg.SetValue("ProxyServer", string.Join(";", existingSystemProxyValues.Select(x => x.ToString()).ToArray()));
             }
 
             Refresh();
         }
 
-        /// <summary>
-        /// Removes the https proxy setting to nothing
-        /// </summary>
-        internal  void RemoveHttpsProxy()
+        private void RemoveProxy(ProxyProtocolType protocolType)
         {
             var reg = Registry.CurrentUser.OpenSubKey(
-                    "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
-            if (reg != null)
+                "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
+            if (reg?.GetValue("ProxyServer") != null)
             {
-                if (reg.GetValue("ProxyServer") != null)
+                var exisitingContent = reg.GetValue("ProxyServer") as string;
+
+                var existingSystemProxyValues = GetSystemProxyValues(exisitingContent);
+                existingSystemProxyValues.RemoveAll(x => protocolType == ProxyProtocolType.Https ? x.IsHttps : !x.IsHttps);
+
+                if (existingSystemProxyValues.Count != 0)
                 {
-                    var exisitingContent = reg.GetValue("ProxyServer") as string;
-
-                    var existingSystemProxyValues = GetSystemProxyValues(exisitingContent);
-                    existingSystemProxyValues.RemoveAll(x => x.IsHttps);
-
-                    if (!(existingSystemProxyValues.Count() == 0))
-                    {
-                        reg.SetValue("ProxyEnable", 1);
-                        reg.SetValue("ProxyServer", String.Join(";", existingSystemProxyValues.Select(x => x.ToString()).ToArray()));
-                    }
-                    else
-                    {
-                        reg.SetValue("ProxyEnable", 0);
-                        reg.SetValue("ProxyServer", string.Empty);
-                    }
-
+                    reg.SetValue("ProxyEnable", 1);
+                    reg.SetValue("ProxyServer", string.Join(";", existingSystemProxyValues.Select(x => x.ToString()).ToArray()));
+                }
+                else
+                {
+                    reg.SetValue("ProxyEnable", 0);
+                    reg.SetValue("ProxyServer", string.Empty);
                 }
             }
 
@@ -170,7 +130,7 @@ namespace Titanium.Web.Proxy.Helpers
         /// <summary>
         /// Removes all types of proxy settings (both http & https)
         /// </summary>
-        internal  void DisableAllProxy()
+        internal void DisableAllProxy()
         {
             var reg = Registry.CurrentUser.OpenSubKey(
                 "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
@@ -189,7 +149,7 @@ namespace Titanium.Web.Proxy.Helpers
         /// </summary>
         /// <param name="prevServerValue"></param>
         /// <returns></returns>
-        private  List<HttpSystemProxyValue> GetSystemProxyValues(string prevServerValue)
+        private List<HttpSystemProxyValue> GetSystemProxyValues(string prevServerValue)
         {
             var result = new List<HttpSystemProxyValue>();
 
@@ -200,16 +160,11 @@ namespace Titanium.Web.Proxy.Helpers
 
             if (proxyValues.Length > 0)
             {
-                foreach (var value in proxyValues)
-                {
-                    var parsedValue = parseProxyValue(value);
-                    if (parsedValue != null)
-                        result.Add(parsedValue);
-                }
+                result.AddRange(proxyValues.Select(ParseProxyValue).Where(parsedValue => parsedValue != null));
             }
             else
             {
-                var parsedValue = parseProxyValue(prevServerValue);
+                var parsedValue = ParseProxyValue(prevServerValue);
                 if (parsedValue != null)
                     result.Add(parsedValue);
             }
@@ -222,29 +177,21 @@ namespace Titanium.Web.Proxy.Helpers
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        private  HttpSystemProxyValue parseProxyValue(string value)
+        private HttpSystemProxyValue ParseProxyValue(string value)
         {
             var tmp = Regex.Replace(value, @"\s+", " ").Trim().ToLower();
-            if (tmp.StartsWith("http="))
+
+            if (tmp.StartsWith("http=") || tmp.StartsWith("https="))
             {
                 var endPoint = tmp.Substring(5);
                 return new HttpSystemProxyValue()
                 {
                     HostName = endPoint.Split(':')[0],
                     Port = int.Parse(endPoint.Split(':')[1]),
-                    IsHttps = false
-                };
+                    IsHttps = tmp.StartsWith("https=")
+				};
             }
-            else if (tmp.StartsWith("https="))
-            {
-                var endPoint = tmp.Substring(5);
-                return new HttpSystemProxyValue()
-                {
-                    HostName = endPoint.Split(':')[0],
-                    Port = int.Parse(endPoint.Split(':')[1]),
-                    IsHttps = true
-                };
-            }
+
             return null;
 
         }
@@ -252,7 +199,7 @@ namespace Titanium.Web.Proxy.Helpers
         /// Prepares the proxy server registry (create empty values if they don't exist) 
         /// </summary>
         /// <param name="reg"></param>
-        private  void prepareRegistry(RegistryKey reg)
+        private static void PrepareRegistry(RegistryKey reg)
         {
             if (reg.GetValue("ProxyEnable") == null)
             {
@@ -269,7 +216,7 @@ namespace Titanium.Web.Proxy.Helpers
         /// <summary>
         /// Refresh the settings so that the system know about a change in proxy setting
         /// </summary>
-        private  void Refresh()
+        private void Refresh()
         {
             NativeMethods.InternetSetOption(IntPtr.Zero, InternetOptionSettingsChanged, IntPtr.Zero, 0);
             NativeMethods.InternetSetOption(IntPtr.Zero, InternetOptionRefresh, IntPtr.Zero, 0);

--- a/Titanium.Web.Proxy/Helpers/Tcp.cs
+++ b/Titanium.Web.Proxy/Helpers/Tcp.cs
@@ -2,20 +2,116 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
 using Titanium.Web.Proxy.Extensions;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Network;
+using Titanium.Web.Proxy.Tcp;
 
 namespace Titanium.Web.Proxy.Helpers
 {
+    internal partial class NativeMethods
+    {
+        internal const int AfInet = 2;
+
+        internal enum TcpTableType
+        {
+            BasicListener,
+            BasicConnections,
+            BasicAll,
+            OwnerPidListener,
+            OwnerPidConnections,
+            OwnerPidAll,
+            OwnerModuleListener,
+            OwnerModuleConnections,
+            OwnerModuleAll,
+        }
+
+        /// <summary>
+        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366921.aspx"/>
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TcpTable
+        {
+            public uint length;
+            public TcpRow row;
+        }
+
+        /// <summary>
+        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TcpRow
+        {
+            public TcpState state;
+            public uint localAddr;
+            public byte localPort1;
+            public byte localPort2;
+            public byte localPort3;
+            public byte localPort4;
+            public uint remoteAddr;
+            public byte remotePort1;
+            public byte remotePort2;
+            public byte remotePort3;
+            public byte remotePort4;
+            public int owningPid;
+        }
+
+        /// <summary>
+        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa365928.aspx"/>
+        /// </summary>
+        [DllImport("iphlpapi.dll", SetLastError = true)]
+        internal static extern uint GetExtendedTcpTable(IntPtr tcpTable, ref int size, bool sort, int ipVersion, int tableClass, int reserved);
+    }
 
     internal class TcpHelper
     {
+        /// <summary>
+        /// Gets the extended TCP table.
+        /// </summary>
+        /// <returns>Collection of <see cref="TcpRow"/>.</returns>
+        internal static TcpTable GetExtendedTcpTable()
+        {
+            List<TcpRow> tcpRows = new List<TcpRow>();
+
+            IntPtr tcpTable = IntPtr.Zero;
+            int tcpTableLength = 0;
+
+            if (NativeMethods.GetExtendedTcpTable(tcpTable, ref tcpTableLength, false, NativeMethods.AfInet, (int)NativeMethods.TcpTableType.OwnerPidAll, 0) != 0)
+            {
+                try
+                {
+                    tcpTable = Marshal.AllocHGlobal(tcpTableLength);
+                    if (NativeMethods.GetExtendedTcpTable(tcpTable, ref tcpTableLength, true, NativeMethods.AfInet, (int)NativeMethods.TcpTableType.OwnerPidAll, 0) == 0)
+                    {
+                        NativeMethods.TcpTable table = (NativeMethods.TcpTable)Marshal.PtrToStructure(tcpTable, typeof(NativeMethods.TcpTable));
+
+                        IntPtr rowPtr = (IntPtr)((long)tcpTable + Marshal.SizeOf(table.length));
+
+                        for (int i = 0; i < table.length; ++i)
+                        {
+                            tcpRows.Add(new TcpRow((NativeMethods.TcpRow)Marshal.PtrToStructure(rowPtr, typeof(NativeMethods.TcpRow))));
+                            rowPtr = (IntPtr)((long)rowPtr + Marshal.SizeOf(typeof(NativeMethods.TcpRow)));
+                        }
+                    }
+                }
+                finally
+                {
+                    if (tcpTable != IntPtr.Zero)
+                    {
+                        Marshal.FreeHGlobal(tcpTable);
+                    }
+                }
+            }
+
+            return new TcpTable(tcpRows);
+        }
 
         /// <summary>
         /// relays the input clientStream to the server at the specified host name & port with the given httpCmd & headers as prefix
@@ -103,6 +199,5 @@ namespace Titanium.Web.Proxy.Helpers
                 tcpConnection.Dispose();
             }
         }
-
     }
 }

--- a/Titanium.Web.Proxy/Helpers/Tcp.cs
+++ b/Titanium.Web.Proxy/Helpers/Tcp.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Net.Security;
-using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
@@ -169,30 +168,17 @@ namespace Titanium.Web.Proxy.Helpers
                                                                 
             try
             {
-                TcpClient tunnelClient = tcpConnection.TcpClient;
-
                 Stream tunnelStream = tcpConnection.Stream;
 
                 Task sendRelay;
 
                 //Now async relay all server=>client & client=>server data
-                if (sb != null)
-                {
-                    sendRelay = clientStream.CopyToAsync(sb.ToString(), tunnelStream);
-                }
-                else
-                {
-                    sendRelay = clientStream.CopyToAsync(string.Empty, tunnelStream);
-                }
+	            sendRelay = clientStream.CopyToAsync(sb?.ToString() ?? string.Empty, tunnelStream);
 
 
-                var receiveRelay = tunnelStream.CopyToAsync(string.Empty, clientStream);
+	            var receiveRelay = tunnelStream.CopyToAsync(string.Empty, clientStream);
 
                 await Task.WhenAll(sendRelay, receiveRelay);
-            }
-            catch
-            {
-                throw;
             }
             finally
             {

--- a/Titanium.Web.Proxy/Http/HttpWebClient.cs
+++ b/Titanium.Web.Proxy/Http/HttpWebClient.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Titanium.Web.Proxy.Helpers;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Network;
 using Titanium.Web.Proxy.Shared;
+using Titanium.Web.Proxy.Tcp;
 
 namespace Titanium.Web.Proxy.Http
 {
@@ -14,6 +17,8 @@ namespace Titanium.Web.Proxy.Http
     /// </summary>
     public class HttpWebClient
     {
+        private int processId;
+
         /// <summary>
         /// Connection to server
         /// </summary>
@@ -23,6 +28,24 @@ namespace Titanium.Web.Proxy.Http
         public List<HttpHeader> ConnectHeaders { get; set; }
         public Request Request { get; set; }
         public Response Response { get; set; }
+
+        /// <summary>
+        /// PID of the process that is created the current session
+        /// </summary>
+        public int ProcessId
+        {
+            get
+            {
+                if (processId == 0)
+                {
+                    TcpRow tcpRow = TcpHelper.GetExtendedTcpTable().TcpRows.FirstOrDefault(row => row.LocalEndPoint.Port == ServerConnection.port);
+
+                    processId = tcpRow?.ProcessId ?? -1;
+                }
+
+                return processId;
+            }
+        }
 
         /// <summary>
         /// Is Https?

--- a/Titanium.Web.Proxy/Http/Request.cs
+++ b/Titanium.Web.Proxy/Http/Request.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Extensions;
@@ -234,13 +233,14 @@ namespace Titanium.Web.Proxy.Http
         /// <summary>
         /// Request Url
         /// </summary>
-        public string Url { get { return RequestUri.OriginalString; } }
+        public string Url => RequestUri.OriginalString;
 
-        /// <summary>
+	    /// <summary>
         /// Encoding for this request
         /// </summary>
-        internal Encoding Encoding { get { return this.GetEncoding(); } }
-        /// <summary>
+        internal Encoding Encoding => this.GetEncoding();
+
+	    /// <summary>
         /// Terminates the underlying Tcp Connection to client after current request
         /// </summary>
         internal bool CancelRequest { get; set; }

--- a/Titanium.Web.Proxy/Http/Response.cs
+++ b/Titanium.Web.Proxy/Http/Response.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Extensions;
@@ -16,9 +15,9 @@ namespace Titanium.Web.Proxy.Http
         public string ResponseStatusCode { get; set; }
         public string ResponseStatusDescription { get; set; }
 
-        internal Encoding Encoding { get { return this.GetResponseCharacterEncoding(); } }
+        internal Encoding Encoding => this.GetResponseCharacterEncoding();
 
-        /// <summary>
+	    /// <summary>
         /// Content encoding for this response
         /// </summary>
         internal string ContentEncoding

--- a/Titanium.Web.Proxy/Http/Responses/OkResponse.cs
+++ b/Titanium.Web.Proxy/Http/Responses/OkResponse.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// 200 Ok response
     /// </summary>
-    public class OkResponse : Response
+    public sealed class OkResponse : Response
     {
         public OkResponse()
         {

--- a/Titanium.Web.Proxy/Http/Responses/RedirectResponse.cs
+++ b/Titanium.Web.Proxy/Http/Responses/RedirectResponse.cs
@@ -1,11 +1,9 @@
-﻿using Titanium.Web.Proxy.Network;
-
-namespace Titanium.Web.Proxy.Http.Responses
+﻿namespace Titanium.Web.Proxy.Http.Responses
 {
     /// <summary>
     /// Redirect response
     /// </summary>
-    public class RedirectResponse : Response
+    public sealed class RedirectResponse : Response
     {
         public RedirectResponse()
         {

--- a/Titanium.Web.Proxy/Network/CertificateManager.cs
+++ b/Titanium.Web.Proxy/Network/CertificateManager.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using System.Threading;
 using System.Linq;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Diagnostics;
 
 namespace Titanium.Web.Proxy.Network
 {

--- a/Titanium.Web.Proxy/Network/TcpConnectionFactory.cs
+++ b/Titanium.Web.Proxy/Network/TcpConnectionFactory.cs
@@ -56,11 +56,11 @@ namespace Titanium.Web.Proxy.Network
 
                     using (var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize, true))
                     {
-                        await writer.WriteLineAsync(string.Format("CONNECT {0}:{1} HTTP/{2}", remoteHostName, remotePort,httpVersion));
-                        await writer.WriteLineAsync(string.Format("Host: {0}:{1}", remoteHostName, remotePort));
+                        await writer.WriteLineAsync($"CONNECT {remoteHostName}:{remotePort} HTTP/{httpVersion}");
+                        await writer.WriteLineAsync($"Host: {remoteHostName}:{remotePort}");
                         await writer.WriteLineAsync("Connection: Keep-Alive");
 
-                        if (externalHttpsProxy.UserName != null && externalHttpsProxy.UserName != "" && externalHttpsProxy.Password != null)
+                        if (!string.IsNullOrEmpty(externalHttpsProxy.UserName) && externalHttpsProxy.Password != null)
                         {
                             await writer.WriteLineAsync("Proxy-Connection: keep-alive");
                             await writer.WriteLineAsync("Proxy-Authorization" + ": Basic " + Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(externalHttpsProxy.UserName + ":" + externalHttpsProxy.Password)));

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -9,7 +9,6 @@ using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Network;
 using System.Linq;
 using System.Security.Authentication;
-using System.Collections.Concurrent;
 
 namespace Titanium.Web.Proxy
 {
@@ -156,6 +155,11 @@ namespace Titanium.Web.Proxy
         /// List of supported Ssl versions
         /// </summary>
         public SslProtocols SupportedSslProtocols { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Ssl3;
+
+        /// <summary>
+        /// Is the proxy currently running
+        /// </summary>
+        public bool ProxyRunning => proxyRunning;
 
         /// <summary>
         /// Constructor

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -17,22 +17,13 @@ namespace Titanium.Web.Proxy
     /// </summary>
     public partial class ProxyServer : IDisposable
     {
-        private static Action<Exception> _exceptionFunc=null;
+	    private static readonly Lazy<Action<Exception>> _defaultExceptionFunc = new Lazy<Action<Exception>>(() => (e => { }));
+        private static Action<Exception> _exceptionFunc;
         public static Action<Exception> ExceptionFunc
         {
             get
             {
-                if(_exceptionFunc!=null)
-                {
-                    return _exceptionFunc;
-                }
-                else
-                {
-                    return (e)=>
-                    {
-
-                    };
-                }
+				return _exceptionFunc ?? _defaultExceptionFunc.Value;
             }
             set
             {

--- a/Titanium.Web.Proxy/Tcp/TcpRow.cs
+++ b/Titanium.Web.Proxy/Tcp/TcpRow.cs
@@ -1,0 +1,35 @@
+﻿using System.Net;
+using Titanium.Web.Proxy.Helpers;
+
+namespace Titanium.Web.Proxy.Tcp
+{
+    /// <summary>
+    /// Represents a managed interface of IP Helper API TcpRow struct
+    /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
+    /// </summary>
+    internal class TcpRow
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpRow"/> class.
+        /// </summary>
+        /// <param name="tcpRow">TcpRow struct.</param>
+        public TcpRow(NativeMethods.TcpRow tcpRow)
+        {
+            ProcessId = tcpRow.owningPid;
+
+            int localPort = (tcpRow.localPort1 << 8) + (tcpRow.localPort2) + (tcpRow.localPort3 << 24) + (tcpRow.localPort4 << 16);
+            long localAddress = tcpRow.localAddr;
+            LocalEndPoint = new IPEndPoint(localAddress, localPort);
+        }
+
+        /// <summary>
+        /// Gets the local end point.
+        /// </summary>
+        public IPEndPoint LocalEndPoint { get; private set; }
+
+        /// <summary>
+        /// Gets the process identifier.
+        /// </summary>
+        public int ProcessId { get; private set; }
+    }
+}

--- a/Titanium.Web.Proxy/Tcp/TcpTable.cs
+++ b/Titanium.Web.Proxy/Tcp/TcpTable.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Titanium.Web.Proxy.Tcp
+{
+    /// <summary>
+    /// Represents collection of TcpRows
+    /// </summary>
+    /// <seealso cref="System.Collections.Generic.IEnumerable{Titanium.Web.Proxy.Tcp.TcpRow}" />
+    internal class TcpTable : IEnumerable<TcpRow>
+    {
+        private readonly IEnumerable<TcpRow> tcpRows;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpTable"/> class.
+        /// </summary>
+        /// <param name="tcpRows">TcpRow collection to initialize with.</param>
+        public TcpTable(IEnumerable<TcpRow> tcpRows)
+        {
+            this.tcpRows = tcpRows;
+        }
+
+        /// <summary>
+        /// Gets the TCP rows.
+        /// </summary>
+        public IEnumerable<TcpRow> TcpRows => tcpRows;
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<TcpRow> GetEnumerator()
+        {
+            return tcpRows.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -93,6 +93,8 @@
     <Compile Include="Http\Responses\OkResponse.cs" />
     <Compile Include="Http\Responses\RedirectResponse.cs" />
     <Compile Include="Shared\ProxyConstants.cs" />
+    <Compile Include="Tcp\TcpRow.cs" />
+    <Compile Include="Tcp\TcpTable.cs" />
   </ItemGroup>
   <ItemGroup>
     <COMReference Include="CERTENROLLLib">


### PR DESCRIPTION
* ProxyRunning property is added to ProxyServer class.
* IP Helper API 'GetExtendedTcpTable' method and relevant structures are wrapped.
* ProcessId property is added to HttpWebClient class.
* Various code refactorings are applied.