### PR TITLE
Proxy exception

### DIFF
--- a/Titanium.Web.Proxy/Exceptions/BodyNotFoundException.cs
+++ b/Titanium.Web.Proxy/Exceptions/BodyNotFoundException.cs
@@ -5,7 +5,7 @@ namespace Titanium.Web.Proxy.Exceptions
     /// <summary>
     /// An expception thrown when body is unexpectedly empty
     /// </summary>
-    public class BodyNotFoundException : Exception
+    public class BodyNotFoundException : ProxyException
     {
         public BodyNotFoundException(string message)
             : base(message)

--- a/Titanium.Web.Proxy/Exceptions/ProxyAuthorizationException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyAuthorizationException.cs
@@ -9,7 +9,12 @@ namespace Titanium.Web.Proxy.Exceptions
     /// </summary>
     public class ProxyAuthorizationException : ProxyException
     {
-
+        /// <summary>
+        /// Instantiate new instance
+        /// </summary>
+        /// <param name="message">Exception message</param>
+        /// <param name="innerException">Inner exception associated to upstream proxy authorization</param>
+        /// <param name="headers">Http's headers associated</param>
         public ProxyAuthorizationException(string message, Exception innerException, IEnumerable<HttpHeader> headers) : base(message, innerException)
         {
             Headers = headers;

--- a/Titanium.Web.Proxy/Exceptions/ProxyAuthorizationException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyAuthorizationException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using Titanium.Web.Proxy.Models;
+
+namespace Titanium.Web.Proxy.Exceptions
+{
+    /// <summary>
+    /// Proxy authorization exception
+    /// </summary>
+    public class ProxyAuthorizationException : ProxyException
+    {
+
+        public ProxyAuthorizationException(string message, Exception innerException, IEnumerable<HttpHeader> headers) : base(message, innerException)
+        {
+            Headers = headers;
+        }
+
+        /// <summary>
+        /// Headers associated with the authorization exception
+        /// </summary>
+        public IEnumerable<HttpHeader> Headers { get; }
+    }
+}

--- a/Titanium.Web.Proxy/Exceptions/ProxyException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyException.cs
@@ -7,6 +7,11 @@ namespace Titanium.Web.Proxy.Exceptions
     /// </summary>
     public abstract class ProxyException : Exception
     {
+        /// <summary>
+        /// Instantiate this exception - must be invoked by derived classes' constructors
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
         protected ProxyException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/Titanium.Web.Proxy/Exceptions/ProxyException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyException.cs
@@ -8,10 +8,18 @@ namespace Titanium.Web.Proxy.Exceptions
     public abstract class ProxyException : Exception
     {
         /// <summary>
+        /// Instantiate a new instance of this exception - must be invoked by derived classes' constructors
+        /// </summary>
+        /// <param name="message">Exception message</param>
+        protected ProxyException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
         /// Instantiate this exception - must be invoked by derived classes' constructors
         /// </summary>
-        /// <param name="message"></param>
-        /// <param name="innerException"></param>
+        /// <param name="message">Excception message</param>
+        /// <param name="innerException">Inner exception associated</param>
         protected ProxyException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/Titanium.Web.Proxy/Exceptions/ProxyException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Titanium.Web.Proxy.Exceptions
+{
+    /// <summary>
+    /// Base class exception associated with this proxy implementation
+    /// </summary>
+    public abstract class ProxyException : Exception
+    {
+        protected ProxyException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Titanium.Web.Proxy/Exceptions/ProxyHttpException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyHttpException.cs
@@ -13,10 +13,10 @@ namespace Titanium.Web.Proxy.Exceptions
         /// </summary>
         /// <param name="message">Message for this exception</param>
         /// <param name="innerException">Associated inner exception</param>
-        /// <param name="sessionInfo">Instance of <see cref="SessionEventArgs"/> associated to the exception</param>
-        public ProxyHttpException(string message, Exception innerException, SessionEventArgs sessionInfo) : base(message, innerException)
+        /// <param name="sessionEventArgs">Instance of <see cref="EventArguments.SessionEventArgs"/> associated to the exception</param>
+        public ProxyHttpException(string message, Exception innerException, SessionEventArgs sessionEventArgs) : base(message, innerException)
         {
-            SessionInfo = sessionInfo;
+            SessionEventArgs = sessionEventArgs;
         }
 
         /// <summary>
@@ -25,6 +25,6 @@ namespace Titanium.Web.Proxy.Exceptions
         /// <remarks>
         /// This object should not be edited
         /// </remarks>
-        public SessionEventArgs SessionInfo { get; }
+        public SessionEventArgs SessionEventArgs { get; }
     }
 }

--- a/Titanium.Web.Proxy/Exceptions/ProxyHttpException.cs
+++ b/Titanium.Web.Proxy/Exceptions/ProxyHttpException.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Titanium.Web.Proxy.EventArguments;
+
+namespace Titanium.Web.Proxy.Exceptions
+{
+    /// <summary>
+    /// Proxy HTTP exception
+    /// </summary>
+    public class ProxyHttpException : ProxyException
+    {
+        /// <summary>
+        /// Instantiate new instance
+        /// </summary>
+        /// <param name="message">Message for this exception</param>
+        /// <param name="innerException">Associated inner exception</param>
+        /// <param name="sessionInfo">Instance of <see cref="SessionEventArgs"/> associated to the exception</param>
+        public ProxyHttpException(string message, Exception innerException, SessionEventArgs sessionInfo) : base(message, innerException)
+        {
+            SessionInfo = sessionInfo;
+        }
+
+        /// <summary>
+        /// Gets session info associated to the exception
+        /// </summary>
+        /// <remarks>
+        /// This object should not be edited
+        /// </remarks>
+        public SessionEventArgs SessionInfo { get; }
+    }
+}

--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -6,6 +6,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Text.RegularExpressions;
+using Titanium.Web.Proxy.Exceptions;
 using Titanium.Web.Proxy.EventArguments;
 using Titanium.Web.Proxy.Helpers;
 using Titanium.Web.Proxy.Network;
@@ -338,7 +339,7 @@ namespace Titanium.Web.Proxy
             }
             catch (Exception e)
             {
-                ExceptionFunc(e);
+                ExceptionFunc(new ProxyHttpException("Error occured whilst handling session request (internal)", e, args));
                 Dispose(args.ProxyClient.ClientStream, args.ProxyClient.ClientStreamReader, args.ProxyClient.ClientStreamWriter, args);
                 return;
             }
@@ -501,7 +502,7 @@ namespace Titanium.Web.Proxy
                 }
                 catch (Exception e)
                 {
-                    ExceptionFunc(e);
+                    ExceptionFunc(new ProxyHttpException("Error occured whilst handling session request", e, args));
                     Dispose(clientStream, clientStreamReader, clientStreamWriter, args);
                     break;
                 }

--- a/Titanium.Web.Proxy/ResponseHandler.cs
+++ b/Titanium.Web.Proxy/ResponseHandler.cs
@@ -5,6 +5,7 @@ using Titanium.Web.Proxy.EventArguments;
 using Titanium.Web.Proxy.Models;
 using Titanium.Web.Proxy.Compression;
 using System.Threading.Tasks;
+using Titanium.Web.Proxy.Exceptions;
 using Titanium.Web.Proxy.Extensions;
 using Titanium.Web.Proxy.Http;
 using Titanium.Web.Proxy.Helpers;
@@ -121,7 +122,7 @@ namespace Titanium.Web.Proxy
             }
             catch(Exception e)
             {
-                ExceptionFunc(e);
+                ExceptionFunc(new ProxyHttpException("Error occured wilst handling session response", e, args));
                 Dispose(args.ProxyClient.ClientStream, args.ProxyClient.ClientStreamReader,
                     args.ProxyClient.ClientStreamWriter, args);
             }

--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -68,6 +68,9 @@
     <Compile Include="Network\CertificateMaker.cs" />
     <Compile Include="Network\ProxyClient.cs" />
     <Compile Include="Exceptions\BodyNotFoundException.cs" />
+    <Compile Include="Exceptions\ProxyAuthorizationException.cs" />
+    <Compile Include="Exceptions\ProxyException.cs" />
+    <Compile Include="Exceptions\ProxyHttpException.cs" />
     <Compile Include="Extensions\HttpWebResponseExtensions.cs" />
     <Compile Include="Extensions\HttpWebRequestExtensions.cs" />
     <Compile Include="Network\CertificateManager.cs" />

--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -25,6 +25,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Debug\Titanium.Web.Proxy.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,6 +33,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DefineConstants>NET45</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Release\Titanium.Web.Proxy.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ionic.Zip, Version=1.9.8.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">


### PR DESCRIPTION
Hi,

I found that, when there is exception when creating connection, there is no direct way for this `ProxyServer` class to know if a request is ever successful. When I look at the `ExceptionFunc` caller, there is no additional context provided, other than original thrown exception.

Therefore, I created a few custom exceptions, such has `ProxyHttpException`, that will contain additional context, `SessionEventArgs`, just like the same thing available to `BeforeRequest` and `BeforeResponse` event.

With this minor changes, `ProxyServer` caller that define `ExceptionFunc` will have additional context information about exception triggered. For example, now, caller could track if a request fails, then, plan to come out with appropriate response - this is something we work more on the future to make it easier to provide response to client (in the event of exception).

Thank you.

regards, Nordin

Doneness:
- [ ] Build is okay - I made sure that this change is building successfully.
- [ ] No Bugs - I made sure that this change is working properly as expected. It does'nt have any bugs that you are aware of. 
- [ ] Branching - If this is not a hotfix, I am making this request against release branch (aka beta branch)
