### PR TITLE
Bind proxy requests to specific network adapter

### DIFF
--- a/Titanium.Web.Proxy/Helpers/Tcp.cs
+++ b/Titanium.Web.Proxy/Helpers/Tcp.cs
@@ -15,6 +15,8 @@ using Titanium.Web.Proxy.Shared;
 
 namespace Titanium.Web.Proxy.Helpers
 {
+    using System.Net;
+
     internal enum IpVersion
     {
         Ipv4 = 1,
@@ -173,7 +175,7 @@ namespace Titanium.Web.Proxy.Helpers
                                         remoteHostName, remotePort,
                                         httpVersion, isHttps, 
                                         supportedProtocols, remoteCertificateValidationCallback, localCertificateSelectionCallback, 
-                                        null, null, clientStream);
+                                        null, null, clientStream, new IPEndPoint(IPAddress.Any, 0));
                                                                 
             try
             {

--- a/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -12,6 +12,8 @@ using Titanium.Web.Proxy.Shared;
 
 namespace Titanium.Web.Proxy.Network.Tcp
 {
+    using System.Net;
+
     /// <summary>
     /// A class that manages Tcp Connection to server used by this proxy server
     /// </summary>
@@ -40,7 +42,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
             bool isHttps, SslProtocols supportedSslProtocols,
             RemoteCertificateValidationCallback remoteCertificateValidationCallback, LocalCertificateSelectionCallback localCertificateSelectionCallback,
             ExternalProxy externalHttpProxy, ExternalProxy externalHttpsProxy,
-            Stream clientStream)
+            Stream clientStream, EndPoint localEndPoint)
         {
             TcpClient client;
             Stream stream;
@@ -52,7 +54,9 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 //If this proxy uses another external proxy then create a tunnel request for HTTPS connections
                 if (externalHttpsProxy != null && externalHttpsProxy.HostName != remoteHostName)
                 {
-                    client = new TcpClient(externalHttpsProxy.HostName, externalHttpsProxy.Port);
+                    client = new TcpClient();
+                    client.Client.Bind(localEndPoint);
+                    client.Client.Connect(externalHttpsProxy.HostName, externalHttpsProxy.Port);
                     stream = client.GetStream();
 
                     using (var writer = new StreamWriter(stream, Encoding.ASCII, bufferSize, true) { NewLine = ProxyConstants.NewLine })
@@ -76,7 +80,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                         var result = await reader.ReadLineAsync();
 
 
-                        if (!new string[] { "200 OK", "connection established" }.Any(s=> result.ToLower().Contains(s.ToLower())))
+                        if (!new string[] { "200 OK", "connection established" }.Any(s => result.ToLower().Contains(s.ToLower())))
                         {
                             throw new Exception("Upstream proxy failed to create a secure tunnel");
                         }
@@ -86,7 +90,9 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 }
                 else
                 {
-                    client = new TcpClient(remoteHostName, remotePort);
+                    client = new TcpClient();
+                    client.Client.Bind(localEndPoint);
+                    client.Client.Connect(remoteHostName, remotePort);
                     stream = client.GetStream();
                 }
 
@@ -110,12 +116,16 @@ namespace Titanium.Web.Proxy.Network.Tcp
             {
                 if (externalHttpProxy != null && externalHttpProxy.HostName != remoteHostName)
                 {
-                    client = new TcpClient(externalHttpProxy.HostName, externalHttpProxy.Port);
+                    client = new TcpClient();
+                    client.Client.Bind(localEndPoint);
+                    client.Client.Connect(externalHttpProxy.HostName, externalHttpProxy.Port);
                     stream = client.GetStream();
                 }
                 else
                 {
-                    client = new TcpClient(remoteHostName, remotePort);
+                    client = new TcpClient();
+                    client.Client.Bind(localEndPoint);
+                    client.Client.Connect(remoteHostName, remotePort);
                     stream = client.GetStream();
                 }
             }
@@ -125,6 +135,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
             stream.ReadTimeout = connectionTimeOutSeconds * 1000;
             stream.WriteTimeout = connectionTimeOutSeconds * 1000;
+
 
             return new TcpConnection()
             {

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -118,6 +118,11 @@ namespace Titanium.Web.Proxy
         public ExternalProxy UpStreamHttpsProxy { get; set; }
 
         /// <summary>
+        /// Local adapter endpoint
+        /// </summary>
+        public EndPoint LocalEndPoint { get; set; } = new IPEndPoint(IPAddress.Any, 0);
+
+        /// <summary>
         /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication
         /// </summary>
         public event Func<object, CertificateValidationEventArgs, Task> ServerCertificateValidationCallback;

--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -251,7 +251,7 @@ namespace Titanium.Web.Proxy
                         args.IsHttps, SupportedSslProtocols,
                         new RemoteCertificateValidationCallback(ValidateServerCertificate),
                         new LocalCertificateSelectionCallback(SelectClientCertificate),
-                        customUpStreamHttpProxy ?? UpStreamHttpProxy, customUpStreamHttpsProxy ?? UpStreamHttpsProxy, args.ProxyClient.ClientStream);
+                        customUpStreamHttpProxy ?? UpStreamHttpProxy, customUpStreamHttpsProxy ?? UpStreamHttpsProxy, args.ProxyClient.ClientStream, LocalEndPoint);
                 }
 
                 args.WebSession.Request.RequestLocked = true;


### PR DESCRIPTION
Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It does'nt have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against release branch (aka beta branch)

Allows binding the proxy to a specific network adapter.

proxyServer.LocalEndPoint = new IPEndPoint(IPAddress.Parse("192.168.1.2"), 0);

