### PR TITLE
Minor XML syntax modifications

### DIFF
--- a/Titanium.Web.Proxy/Helpers/SystemProxy.cs
+++ b/Titanium.Web.Proxy/Helpers/SystemProxy.cs
@@ -125,7 +125,7 @@ namespace Titanium.Web.Proxy.Helpers
         }
 
         /// <summary>
-        /// Removes all types of proxy settings (both http & https)
+        /// Removes all types of proxy settings (both http and https)
         /// </summary>
         internal void DisableAllProxy()
         {

--- a/Titanium.Web.Proxy/Helpers/Tcp.cs
+++ b/Titanium.Web.Proxy/Helpers/Tcp.cs
@@ -42,7 +42,7 @@ namespace Titanium.Web.Proxy.Helpers
         }
 
         /// <summary>
-        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366921.aspx"/>
+        /// <see href="http://msdn2.microsoft.com/en-us/library/aa366921.aspx"/>
         /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         internal struct TcpTable
@@ -52,7 +52,7 @@ namespace Titanium.Web.Proxy.Helpers
         }
 
         /// <summary>
-        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
+        /// <see href="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
         /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         internal struct TcpRow
@@ -72,7 +72,7 @@ namespace Titanium.Web.Proxy.Helpers
         }
 
         /// <summary>
-        /// <see cref="http://msdn2.microsoft.com/en-us/library/aa365928.aspx"/>
+        /// <see href="http://msdn2.microsoft.com/en-us/library/aa365928.aspx"/>
         /// </summary>
         [DllImport("iphlpapi.dll", SetLastError = true)]
         internal static extern uint GetExtendedTcpTable(IntPtr tcpTable, ref int size, bool sort, int ipVersion, int tableClass, int reserved);
@@ -124,7 +124,7 @@ namespace Titanium.Web.Proxy.Helpers
         }
 
         /// <summary>
-        /// relays the input clientStream to the server at the specified host name & port with the given httpCmd & headers as prefix
+        /// relays the input clientStream to the server at the specified host name and port with the given httpCmd and headers as prefix
         /// Usefull for websocket requests
         /// </summary>
         /// <param name="bufferSize"></param>

--- a/Titanium.Web.Proxy/Http/HttpWebClient.cs
+++ b/Titanium.Web.Proxy/Http/HttpWebClient.cs
@@ -66,7 +66,7 @@ namespace Titanium.Web.Proxy.Http
   
 
         /// <summary>
-        /// Prepare & send the http(s) request
+        /// Prepare and send the http(s) request
         /// </summary>
         /// <returns></returns>
         internal async Task SendRequest(bool enable100ContinueBehaviour)
@@ -148,7 +148,7 @@ namespace Titanium.Web.Proxy.Http
         }
 
         /// <summary>
-        /// Receive & parse the http response from server
+        /// Receive and parse the http response from server
         /// </summary>
         /// <returns></returns>
         internal async Task ReceiveResponse()

--- a/Titanium.Web.Proxy/Network/Certificate/BCCertificateMaker.cs
+++ b/Titanium.Web.Proxy/Network/Certificate/BCCertificateMaker.cs
@@ -48,6 +48,7 @@ namespace Titanium.Web.Proxy.Network.Certificate
         /// <param name="keyStrength">The key strength.</param>
         /// <param name="signatureAlgorithm">The signature algorithm.</param>
         /// <param name="issuerPrivateKey">The issuer private key.</param>
+		/// <param name="hostName">The host name</param>
         /// <returns>X509Certificate2 instance.</returns>
         /// <exception cref="PemException">Malformed sequence in RSA private key</exception>
         private static X509Certificate2 GenerateCertificate(string hostName,

--- a/Titanium.Web.Proxy/Network/Tcp/TcpConnection.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpConnection.cs
@@ -7,7 +7,7 @@ using Titanium.Web.Proxy.Models;
 namespace Titanium.Web.Proxy.Network.Tcp
 {
     /// <summary>
-    /// An object that holds TcpConnection to a particular server & port
+    /// An object that holds TcpConnection to a particular server and port
     /// </summary>
     public class TcpConnection : IDisposable
     {

--- a/Titanium.Web.Proxy/Network/Tcp/TcpRow.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpRow.cs
@@ -5,7 +5,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
 {
     /// <summary>
     /// Represents a managed interface of IP Helper API TcpRow struct
-    /// <see cref="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
+    /// <see href="http://msdn2.microsoft.com/en-us/library/aa366913.aspx"/>
     /// </summary>
     internal class TcpRow
     {


### PR DESCRIPTION
Minor modifications made to XML syntax to reduce warnings generated during compile.

This is my first code change contribution to a public open source project on GitHub.

As you will note, it modifies some XML statements in various files to be syntactically correct.  The only effect of this modification is to reduce warnings during compile.  I figure this patch has minimum potential to upset the apple cart while I try to figure out how best to contribute something useful.

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It does'nt have any bugs that I am aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against develop branch 