### PR TITLE
ArgumentException fix when proxy dll is loaded dynamically

### DIFF
--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -54,9 +54,9 @@ namespace Titanium.Web.Proxy
                 var httpCmdSplit = httpCmd.Split(ProxyConstants.SpaceSplit, 3);
 
                 //Find the request Verb
-                var httpVerb = httpCmdSplit[0];
+                var httpVerb = httpCmdSplit[0].ToUpper();
 
-                httpRemoteUri = httpVerb.ToUpper() == "CONNECT" ? 
+                httpRemoteUri = httpVerb == "CONNECT" ? 
                     new Uri("http://" + httpCmdSplit[1]) : new Uri(httpCmdSplit[1]);
 
                 //parse the HTTP version
@@ -78,7 +78,7 @@ namespace Titanium.Web.Proxy
                 List<HttpHeader> connectRequestHeaders = null;
 
                 //Client wants to create a secure tcp tunnel (its a HTTPS request)
-                if (httpVerb.ToUpper() == "CONNECT" && !excluded && httpRemoteUri.Port != 80)
+                if (httpVerb == "CONNECT" && !excluded && httpRemoteUri.Port != 80)
                 {
                     httpRemoteUri = new Uri("https://" + httpCmdSplit[1]);
                     string tmpLine;
@@ -131,7 +131,7 @@ namespace Titanium.Web.Proxy
 
                 }
                 //Sorry cannot do a HTTPS request decrypt to port 80 at this time
-                else if (httpVerb.ToUpper() == "CONNECT")
+                else if (httpVerb == "CONNECT")
                 {
                     //Cyphen out CONNECT request headers
                     await clientStreamReader.ReadAllLinesAsync();


### PR DESCRIPTION
If you load an assembly dynamically, the Location property is string.Empty:
https://msdn.microsoft.com/en-us/library/system.reflection.assembly.location(v=vs.110).aspx

In the GetRootCertificate method the Path.GetDirectoryName was called with the assembly.Location parameter. If you call this method with an empty string it throws ArgumentException.

This pull request changes the logic which tries to find the root certificate file. If the executing assemlby is dynamically loaded, tries to get the Location of the Entry assembly. It should be a real file with valid Location.

This logic was used in 2 places, in GetRootCertificate and in CreateTrustedRootCertificate, so I moved it to a common private method.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It does'nt have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
