### PR TITLE
For some reason TCPClient.bind does not work on Mono but the constructor does work...

### DIFF
--- a/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -41,7 +41,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
             bool isHttps, SslProtocols supportedSslProtocols,
             RemoteCertificateValidationCallback remoteCertificateValidationCallback, LocalCertificateSelectionCallback localCertificateSelectionCallback,
             ExternalProxy externalHttpProxy, ExternalProxy externalHttpsProxy,
-            Stream clientStream, EndPoint upStreamEndPoint)
+            Stream clientStream, IPEndPoint upStreamEndPoint)
         {
             TcpClient client;
             Stream stream;
@@ -58,8 +58,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 //If this proxy uses another external proxy then create a tunnel request for HTTPS connections
                 if (useHttpsProxy)
                 {
-                    client = new TcpClient();
-                    client.Client.Bind(upStreamEndPoint);
+                    client = new TcpClient(upStreamEndPoint);
                     await client.ConnectAsync(externalHttpsProxy.HostName, externalHttpsProxy.Port);
                     stream = client.GetStream();
 
@@ -94,8 +93,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 }
                 else
                 {
-                    client = new TcpClient();
-                    client.Client.Bind(upStreamEndPoint);
+                    client = new TcpClient(upStreamEndPoint);
                     await client.ConnectAsync(remoteHostName, remotePort);
                     stream = client.GetStream();
                 }
@@ -120,15 +118,13 @@ namespace Titanium.Web.Proxy.Network.Tcp
             {
                 if (useHttpProxy)
                 {
-                    client = new TcpClient();
-                    client.Client.Bind(upStreamEndPoint);
+                    client = new TcpClient(upStreamEndPoint);
                     await client.ConnectAsync(externalHttpProxy.HostName, externalHttpProxy.Port);
                     stream = client.GetStream();
                 }
                 else
                 {
-                    client = new TcpClient();
-                    client.Client.Bind(upStreamEndPoint);
+                    client = new TcpClient(upStreamEndPoint);
                     await client.ConnectAsync(remoteHostName, remotePort);
                     stream = client.GetStream();
                 }


### PR DESCRIPTION
Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It does'nt have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against develop branch 
