### PR TITLE
Small fixes

### DIFF
--- a/Tests/Titanium.Web.Proxy.UnitTests/CertificateManagerTests.cs
+++ b/Tests/Titanium.Web.Proxy.UnitTests/CertificateManagerTests.cs
@@ -9,7 +9,7 @@ namespace Titanium.Web.Proxy.UnitTests
     [TestClass]
     public class CertificateManagerTests
     {
-        private readonly static string[] hostNames
+        private static readonly string[] hostNames
             = new string[] { "facebook.com", "youtube.com", "google.com",
                                 "bing.com", "yahoo.com"};
 

--- a/Titanium.Web.Proxy/Network/Certificate/BCCertificateMaker.cs
+++ b/Titanium.Web.Proxy/Network/Certificate/BCCertificateMaker.cs
@@ -23,8 +23,8 @@ namespace Titanium.Web.Proxy.Network.Certificate
     /// </summary>
     internal class BCCertificateMaker : ICertificateMaker
     {
-        private const int CertificateValidDays = 1825;
-        private const int CertificateGraceDays = 366;
+        private const int certificateValidDays = 1825;
+        private const int certificateGraceDays = 366;
 
         /// <summary>
         /// Makes the certificate.
@@ -187,7 +187,7 @@ namespace Titanium.Web.Proxy.Network.Certificate
                 return certificate;
             }
 
-            return MakeCertificateInternal(isRoot, subject, $"CN={subject}", DateTime.UtcNow.AddDays(-CertificateGraceDays), DateTime.UtcNow.AddDays(CertificateValidDays), isRoot ? null : signingCert);
+            return MakeCertificateInternal(isRoot, subject, $"CN={subject}", DateTime.UtcNow.AddDays(-certificateGraceDays), DateTime.UtcNow.AddDays(certificateValidDays), isRoot ? null : signingCert);
         }
     }
 

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -87,7 +87,7 @@ namespace Titanium.Web.Proxy
             get { return certificateManager.Issuer; }
             set
             {
-                CreateCertificateCacheManager(certificateManager.RootCertificateName, value);
+                CreateCertificateManager(certificateManager.RootCertificateName, value);
                 certValidated = null;
             }
         }
@@ -104,7 +104,7 @@ namespace Titanium.Web.Proxy
             get { return certificateManager.RootCertificateName; }
             set
             {
-                CreateCertificateCacheManager(value, certificateManager.Issuer);
+                CreateCertificateManager(value, certificateManager.Issuer);
                 certValidated = null;
             }
         }
@@ -272,7 +272,7 @@ namespace Titanium.Web.Proxy
             new FireFoxProxySettingsManager();
 #endif
 
-            CreateCertificateCacheManager(rootCertificateName, rootCertificateIssuerName);
+            CreateCertificateManager(rootCertificateName, rootCertificateIssuerName);
         }
 
         /// <summary>
@@ -557,7 +557,7 @@ namespace Titanium.Web.Proxy
         }
 
 
-        private void CreateCertificateCacheManager(string rootCertificateName, string rootCertificateIssuerName)
+        private void CreateCertificateManager(string rootCertificateName, string rootCertificateIssuerName)
         {
             certificateManager = new CertificateManager(CertificateEngine,
                 rootCertificateIssuerName, rootCertificateName, ExceptionFunc);


### PR DESCRIPTION
I saw that you renamed the CertificateCacheManager, so I renamed the 
CreateCertificateCacheManager to CreateCertificateManager, too

Also noticed that you renamed my private const field to camelCase, I used PascalCase becasuse in the project there were two PascalCase constants in BCCertificateMaker, I renamed those to camelCase. (So now they are the same everywhere)
And swapped the modifier order in CertificateManagerTest

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It does'nt have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
