### PR TITLE
RootCertificate creation improvements

### DIFF
--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -98,6 +98,9 @@ namespace Titanium.Web.Proxy.Examples.Basic
             proxyServer.ClientCertificateSelectionCallback -= OnCertificateSelection;
 
             proxyServer.Stop();
+
+            //remove the generated certificates
+            //proxyServer.CertificateManager.RemoveTrustedRootCertificates();
         }
 
         //intecept & cancel redirect or update requests

--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -17,6 +17,12 @@ namespace Titanium.Web.Proxy.Examples.Basic
         public ProxyTestController()
         {
             proxyServer = new ProxyServer();
+
+            //generate root certificate without storing it in file system
+            //proxyServer.CertificateEngine = Network.CertificateEngine.BouncyCastle;
+            //proxyServer.CertificateManager.CreateTrustedRootCertificate(false);
+            //proxyServer.CertificateManager.TrustRootCertificate();
+
             proxyServer.ExceptionFunc = exception => Console.WriteLine(exception.Message);
             proxyServer.TrustRootCertificate = true;
 

--- a/Titanium.Web.Proxy/Network/CertificateManager.cs
+++ b/Titanium.Web.Proxy/Network/CertificateManager.cs
@@ -29,9 +29,9 @@ namespace Titanium.Web.Proxy.Network
     /// <summary>
     /// A class to manage SSL certificates used by this proxy server
     /// </summary>
-    internal class CertificateManager : IDisposable
+    public class CertificateManager : IDisposable
     {
-        public CertificateEngine Engine
+        internal CertificateEngine Engine
         {
             get { return engine; }
             set
@@ -164,10 +164,13 @@ namespace Titanium.Web.Proxy.Network
         /// <summary>
         /// Attempts to create a RootCertificate
         /// </summary>
-        /// <returns>true if succeeded, else false</returns>
-        internal bool CreateTrustedRootCertificate()
+        /// <param name="persistToFile">if set to <c>true</c> try to load/save the certificate from rootCert.pfx.</param>
+        /// <returns>
+        /// true if succeeded, else false
+        /// </returns>
+        public bool CreateTrustedRootCertificate(bool persistToFile = true)
         {
-            if (RootCertificate == null)
+            if (persistToFile && RootCertificate == null)
             {
                 RootCertificate = LoadRootCertificate();
             }
@@ -186,7 +189,7 @@ namespace Titanium.Web.Proxy.Network
                 exceptionFunc(e);
             }
 
-            if (RootCertificate != null)
+            if (persistToFile && RootCertificate != null)
             {
                 try
                 {
@@ -205,7 +208,7 @@ namespace Titanium.Web.Proxy.Network
         /// <summary>
         /// Trusts the root certificate.
         /// </summary>
-        internal void TrustRootCertificate()
+        public void TrustRootCertificate()
         {
             //current user
             TrustRootCertificate(StoreLocation.CurrentUser);

--- a/Titanium.Web.Proxy/Network/CertificateManager.cs
+++ b/Titanium.Web.Proxy/Network/CertificateManager.cs
@@ -218,6 +218,18 @@ namespace Titanium.Web.Proxy.Network
         }
 
         /// <summary>
+        /// Removes the trusted certificates.
+        /// </summary>
+        public void RemoveTrustedRootCertificates()
+        {
+            //current user
+            RemoveTrustedRootCertificates(StoreLocation.CurrentUser);
+
+            //current system
+            RemoveTrustedRootCertificates(StoreLocation.LocalMachine);
+        }
+
+        /// <summary>
         /// Create an SSL certificate
         /// </summary>
         /// <param name="certificateName"></param>
@@ -325,6 +337,46 @@ namespace Titanium.Web.Proxy.Network
 
                 x509RootStore.Add(RootCertificate);
                 x509PersonalStore.Add(RootCertificate);
+            }
+            catch (Exception e)
+            {
+                exceptionFunc(
+                    new Exception("Failed to make system trust root certificate "
+                                  + $" for {storeLocation} store location. You may need admin rights.", e));
+            }
+            finally
+            {
+                x509RootStore.Close();
+                x509PersonalStore.Close();
+            }
+        }
+
+        /// <summary>
+        /// Remove the Root Certificate trust
+        /// </summary>
+        /// <param name="storeLocation"></param>
+        /// <returns></returns>
+        internal void RemoveTrustedRootCertificates(StoreLocation storeLocation)
+        {
+            if (RootCertificate == null)
+            {
+                exceptionFunc(
+                    new Exception("Could not set root certificate"
+                                  + " as system proxy since it is null or empty."));
+
+                return;
+            }
+
+            X509Store x509RootStore = new X509Store(StoreName.Root, storeLocation);
+            var x509PersonalStore = new X509Store(StoreName.My, storeLocation);
+
+            try
+            {
+                x509RootStore.Open(OpenFlags.ReadWrite);
+                x509PersonalStore.Open(OpenFlags.ReadWrite);
+
+                x509RootStore.Remove(RootCertificate);
+                x509PersonalStore.Remove(RootCertificate);
             }
             catch (Exception e)
             {

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -25,11 +25,6 @@ namespace Titanium.Web.Proxy
         private bool proxyRunning { get; set; }
 
         /// <summary>
-        /// Manages certificates used by this proxy
-        /// </summary>
-        private CertificateManager certificateManager { get; set; }
-
-        /// <summary>
         /// An default exception log func
         /// </summary>
         private readonly Lazy<Action<Exception>> defaultExceptionFunc = new Lazy<Action<Exception>>(() => (e => { }));
@@ -65,12 +60,17 @@ namespace Titanium.Web.Proxy
         public int BufferSize { get; set; } = 8192;
 
         /// <summary>
+        /// Manages certificates used by this proxy
+        /// </summary>
+        public CertificateManager CertificateManager { get; }
+
+        /// <summary>
         /// The root certificate
         /// </summary>
         public X509Certificate2 RootCertificate
         {
-            get { return certificateManager.RootCertificate; }
-            set { certificateManager.RootCertificate = value; }
+            get { return CertificateManager.RootCertificate; }
+            set { CertificateManager.RootCertificate = value; }
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace Titanium.Web.Proxy
         /// </summary>
         public string RootCertificateIssuerName
         {
-            get { return certificateManager.Issuer; }
-            set { certificateManager.RootCertificateName = value; }
+            get { return CertificateManager.Issuer; }
+            set { CertificateManager.RootCertificateName = value; }
         }
 
         /// <summary>
@@ -92,8 +92,8 @@ namespace Titanium.Web.Proxy
         /// </summary>
         public string RootCertificateName
         {
-            get { return certificateManager.RootCertificateName; }
-            set { certificateManager.Issuer = value; }
+            get { return CertificateManager.RootCertificateName; }
+            set { CertificateManager.Issuer = value; }
         }
 
         /// <summary>
@@ -121,8 +121,8 @@ namespace Titanium.Web.Proxy
         /// </summary>
         public CertificateEngine CertificateEngine
         {
-            get { return certificateManager.Engine; }
-            set { certificateManager.Engine = value; }
+            get { return CertificateManager.Engine; }
+            set { CertificateManager.Engine = value; }
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Titanium.Web.Proxy
             new FireFoxProxySettingsManager();
 #endif
 
-            certificateManager = new CertificateManager(ExceptionFunc);
+            CertificateManager = new CertificateManager(ExceptionFunc);
             if (rootCertificateName != null)
             {
                 RootCertificateName = rootCertificateName;
@@ -356,7 +356,7 @@ namespace Titanium.Web.Proxy
             EnsureRootCertificate();
 
             //If certificate was trusted by the machine
-            if (certificateManager.CertValidated)
+            if (CertificateManager.CertValidated)
             {
                 systemProxySettingsManager.SetHttpsProxy(
                     Equals(endPoint.IpAddress, IPAddress.Any) |
@@ -435,7 +435,7 @@ namespace Titanium.Web.Proxy
                 Listen(endPoint);
             }
 
-            certificateManager.ClearIdleCertificates(CertificateCacheTimeOutMinutes);
+            CertificateManager.ClearIdleCertificates(CertificateCacheTimeOutMinutes);
 
             proxyRunning = true;
         }
@@ -468,7 +468,7 @@ namespace Titanium.Web.Proxy
 
             ProxyEndPoints.Clear();
 
-            certificateManager?.StopClearIdleCertificates();
+            CertificateManager?.StopClearIdleCertificates();
 
             proxyRunning = false;
         }
@@ -483,7 +483,7 @@ namespace Titanium.Web.Proxy
                 Stop();
             }
 
-            certificateManager?.Dispose();
+            CertificateManager?.Dispose();
         }
 
         /// <summary>
@@ -543,13 +543,13 @@ namespace Titanium.Web.Proxy
 
         private void EnsureRootCertificate()
         {
-            if (!certificateManager.CertValidated)
+            if (!CertificateManager.CertValidated)
             {
-                certificateManager.CreateTrustedRootCertificate();
+                CertificateManager.CreateTrustedRootCertificate();
 
                 if (TrustRootCertificate)
                 {
-                    certificateManager.TrustRootCertificate();
+                    CertificateManager.TrustRootCertificate();
                 }
             }
         }

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -80,7 +80,7 @@ namespace Titanium.Web.Proxy
         public string RootCertificateIssuerName
         {
             get { return CertificateManager.Issuer; }
-            set { CertificateManager.RootCertificateName = value; }
+            set { CertificateManager.Issuer = value; }
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace Titanium.Web.Proxy
         public string RootCertificateName
         {
             get { return CertificateManager.RootCertificateName; }
-            set { CertificateManager.Issuer = value; }
+            set { CertificateManager.RootCertificateName = value; }
         }
 
         /// <summary>

--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -110,7 +110,7 @@ namespace Titanium.Web.Proxy
                     {
                         sslStream = new SslStream(clientStream, true);
 
-                        var certificate = endPoint.GenericCertificate ?? certificateManager.CreateCertificate(httpRemoteUri.Host, false);
+                        var certificate = endPoint.GenericCertificate ?? CertificateManager.CreateCertificate(httpRemoteUri.Host, false);
 
                         //Successfully managed to authenticate the client using the fake certificate
                         await sslStream.AuthenticateAsServerAsync(certificate, false,
@@ -177,7 +177,7 @@ namespace Titanium.Web.Proxy
                 var sslStream = new SslStream(clientStream, true);
 
                 //implement in future once SNI supported by SSL stream, for now use the same certificate
-                var certificate = certificateManager.CreateCertificate(endPoint.GenericCertificateName, false);
+                var certificate = CertificateManager.CreateCertificate(endPoint.GenericCertificateName, false);
 
                 try
                 {


### PR DESCRIPTION
I'd like to implement my own Root certificate storing mechanism as in #175
Since some days ago it was possible to set the RootCertificate from outside, but I'd like to use the existing certification maker classes. (Don't want to reimplement `WinCertificateMaker` or `BCCertificateMaker` in my own code)
So I changed the Certification provider to public, which has now 3 public methods:
```
public bool CreateTrustedRootCertificate(bool persistToFile = true)
public void TrustRootCertificate()
public void RemoveTrustedRootCertificates()

```

The default behavior is the same as before, it will store the certificate to rootCert.pfx.

I was also thinking on changing the `ICertificateMaker` and `CertificateManger.CertEngine` to public, too.
Maybe it would be useful.

`RemoveTrustedRootCertificates` removes only the root certificates. If you use Bouncy Castle then they are all which are stored in the Windows certmgr.
But if you use Windows CertEnroll(is this the right name?) engine, It will store every single site certificate, so later it would be useful to create another cleanup method which removes them.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
