### PR TITLE
Stream disposing fix, SslStream should dispose the inner stream (true…

### DIFF
--- a/Titanium.Web.Proxy/Helpers/CustomBufferedStream.cs
+++ b/Titanium.Web.Proxy/Helpers/CustomBufferedStream.cs
@@ -147,14 +147,6 @@ namespace Titanium.Web.Proxy.Helpers
         }
 
         /// <summary>
-        /// Closes the current stream and releases any resources (such as sockets and file handles) associated with the current stream. Instead of calling this method, ensure that the stream is properly disposed.
-        /// </summary>
-        public override void Close()
-        {
-            baseStream.Close();
-        }
-
-        /// <summary>
         /// Asynchronously reads the bytes from the current stream and writes them to another stream, using a specified buffer size and cancellation token.
         /// </summary>
         /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>

--- a/Titanium.Web.Proxy/Helpers/Tcp.cs
+++ b/Titanium.Web.Proxy/Helpers/Tcp.cs
@@ -213,7 +213,7 @@ namespace Titanium.Web.Proxy.Helpers
             var tcpConnection = await tcpConnectionFactory.CreateClient(server,
                 remoteHostName, remotePort,
                 httpVersion, isHttps,
-                null, null, clientStream);
+                null, null);
 
             try
             {

--- a/Titanium.Web.Proxy/Network/Tcp/TcpConnection.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpConnection.cs
@@ -26,7 +26,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         /// </summary>
         internal Version Version { get; set; }
 
-        internal TcpClient TcpClient { get; set; }
+        internal TcpClient TcpClient { private get; set; }
 
         /// <summary>
         /// used to read lines from server
@@ -54,7 +54,6 @@ namespace Titanium.Web.Proxy.Network.Tcp
         public void Dispose()
         {
             Stream?.Close();
-            Stream?.Dispose();
 
             StreamReader?.Dispose();
 

--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -111,7 +111,7 @@ namespace Titanium.Web.Proxy
 
                     try
                     {
-                        sslStream = new SslStream(clientStream, true);
+                        sslStream = new SslStream(clientStream);
 
                         var certificate = endPoint.GenericCertificate ??
                                           CertificateManager.CreateCertificate(httpRemoteUri.Host, false);
@@ -191,7 +191,7 @@ namespace Titanium.Web.Proxy
             {
                 if (endPoint.EnableSsl)
                 {
-                    var sslStream = new SslStream(clientStream, true);
+                    var sslStream = new SslStream(clientStream);
                     clientStream = new CustomBufferedStream(sslStream, BufferSize);
 
                     //implement in future once SNI supported by SSL stream, for now use the same certificate
@@ -542,8 +542,7 @@ namespace Titanium.Web.Proxy
                 args.WebSession.Request.HttpVersion,
                 args.IsHttps,
                 customUpStreamHttpProxy ?? UpStreamHttpProxy,
-                customUpStreamHttpsProxy ?? UpStreamHttpsProxy,
-                args.ProxyClient.ClientStream);
+                customUpStreamHttpsProxy ?? UpStreamHttpsProxy);
         }
 
 


### PR DESCRIPTION
… parameter removed)

CreateClient: clientStream parameter was not used

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
