### PR TITLE
Added OS condition for referencing COM library

### DIFF
--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -129,7 +129,7 @@
     <Compile Include="WinAuthHandler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="CERTENROLLLib">
+    <COMReference Include="CERTENROLLLib" Condition="'$(OS)' != 'Unix'">
       <Guid>{728AB348-217D-11DA-B2A4-000E7BBB2B09}</Guid>
       <VersionMajor>1</VersionMajor>
       <VersionMinor>0</VersionMinor>


### PR DESCRIPTION
mono's old xbuild probably ignored this section, but mono's new msbuild tries to find AxImp.exe. This tool is not available on Linux:

> /usr/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2563,5): warning MSB3084: Task attempted to find "AxImp.exe" in two locations. 1) Under the "/usr/lib/mono/4.5/" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "/usr/lib/mono/4.5/" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK. [/home/user/DebSource/PLSProxy/Titanium.Web.Proxy/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj]
/usr/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2563,5): error MSB3086: Task could not find "AxImp.exe" using the SdkToolsPath "/usr/lib/mono/4.5/" or the registry key "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.7\WinSDK-NetFx40Tools-x86". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed [/home/user/DebSource/PLSProxy/Titanium.Web.Proxy/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj]

This condition tells msbuild to skip this COM section on Unix systems.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
