### PR TITLE
On CancelRequest, bypass connection

### DIFF
--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -340,7 +340,7 @@ namespace Titanium.Web.Proxy
                     }
 
                     //if upgrading to websocket then relay the requet without reading the contents
-                    if (args.WebSession.Request.UpgradeToWebSocket)
+                    if (!args.WebSession.Request.CancelRequest && args.WebSession.Request.UpgradeToWebSocket)
                     {
                         await TcpHelper.SendRaw(this,
                             httpRemoteUri.Host, httpRemoteUri.Port,
@@ -351,7 +351,7 @@ namespace Titanium.Web.Proxy
                         break;
                     }
 
-                    if (connection == null)
+                    if (!args.WebSession.Request.CancelRequest && connection == null)
                     {
                         connection = await GetServerConnection(args);
                     }


### PR DESCRIPTION
If args.WebSession.Request.CancelRequest, then GetServerConnection() shouldn't be called.  This fixes the following problems:

1.  If you don't, you'll still to the web-request.   So, in the case when you want to block something like "google.com", and return custom HTML that has text like "Blocked by titanium web proxy", if you set the connection, it will still do the web-request, which is unnecessary, and sometimes may be undesirable.

2.  If someone calls `await e.Ok()` to return custom data, they may want to so based on the absoluteurl containing a hostname that may not even resolve.   For instance "http://xyzxyz/...", and xyzxyz is not a valid hostname.   If you attempt a connection, the dns won't resolve, and the entire thing will be aborted.  This means, the data sent to  `await e.Ok()` doesn't even get returned to the client browser.

Without these changes, I can't use the proxyserver, so please accept the Pull Request, or let me know if there's a different way to do this.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
