### PR TITLE
Detect HTTPS ClientHello instead of manually listing the HTTPS ports +bugfix

### DIFF
--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -43,6 +43,8 @@ namespace Titanium.Web.Proxy.Examples.Basic
         {
             proxyServer.BeforeRequest += OnRequest;
             proxyServer.BeforeResponse += OnResponse;
+            proxyServer.TunnelConnectRequest += OnTunnelConnectRequest;
+            proxyServer.TunnelConnectResponse += OnTunnelConnectResponse;
             proxyServer.ServerCertificateValidationCallback += OnCertificateValidation;
             proxyServer.ClientCertificateSelectionCallback += OnCertificateSelection;
 
@@ -105,6 +107,8 @@ namespace Titanium.Web.Proxy.Examples.Basic
 
         public void Stop()
         {
+            proxyServer.TunnelConnectRequest -= OnTunnelConnectRequest;
+            proxyServer.TunnelConnectResponse -= OnTunnelConnectResponse;
             proxyServer.BeforeRequest -= OnRequest;
             proxyServer.BeforeResponse -= OnResponse;
             proxyServer.ServerCertificateValidationCallback -= OnCertificateValidation;
@@ -114,6 +118,15 @@ namespace Titanium.Web.Proxy.Examples.Basic
 
             //remove the generated certificates
             //proxyServer.CertificateManager.RemoveTrustedRootCertificates();
+        }
+
+        private async Task OnTunnelConnectRequest(object sender, TunnelConnectEventArgs e)
+        {
+            Console.WriteLine("Tunnel to: " + e.ConnectRequest.Host);
+        }
+
+        private async Task OnTunnelConnectResponse(object sender, TunnelConnectEventArgs e)
+        {
         }
 
         //intecept & cancel redirect or update requests

--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -16,8 +16,7 @@ namespace Titanium.Web.Proxy.Examples.Basic
         //share requestBody outside handlers
         //Using a dictionary is not a good idea since it can cause memory overflow
         //ideally the data should be moved out of memory
-        //private readonly IDictionary<Guid, string> requestBodyHistory 
-        //    = new ConcurrentDictionary<Guid, string>();
+        //private readonly IDictionary<Guid, string> requestBodyHistory = new ConcurrentDictionary<Guid, string>();
 
         public ProxyTestController()
         {
@@ -57,11 +56,14 @@ namespace Titanium.Web.Proxy.Examples.Basic
                 ExcludedHttpsHostNameRegex = new List<string>
                 {
                     "dropbox.com"
-                }
+                },
 
                 //Include Https addresses you want to proxy (others will be excluded)
                 //for example github.com
-                //IncludedHttpsHostNameRegex = new List<string> { "github.com" }
+                //IncludedHttpsHostNameRegex = new List<string>
+                //{
+                //    "github.com"
+                //},
 
                 //You can set only one of the ExcludedHttpsHostNameRegex and IncludedHttpsHostNameRegex properties, otherwise ArgumentException will be thrown
 

--- a/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/Examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -120,12 +120,12 @@ namespace Titanium.Web.Proxy.Examples.Basic
             //proxyServer.CertificateManager.RemoveTrustedRootCertificates();
         }
 
-        private async Task OnTunnelConnectRequest(object sender, TunnelConnectEventArgs e)
+        private async Task OnTunnelConnectRequest(object sender, TunnelConnectSessionEventArgs e)
         {
-            Console.WriteLine("Tunnel to: " + e.ConnectRequest.Host);
+            Console.WriteLine("Tunnel to: " + e.WebSession.Request.Host);
         }
 
-        private async Task OnTunnelConnectResponse(object sender, TunnelConnectEventArgs e)
+        private async Task OnTunnelConnectResponse(object sender, TunnelConnectSessionEventArgs e)
         {
         }
 

--- a/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
+++ b/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
@@ -434,7 +434,10 @@ namespace Titanium.Web.Proxy.EventArguments
 
             if (headers != null && headers.Count > 0)
             {
-                response.ResponseHeaders = headers;
+                foreach (var header in headers)
+                {
+                    response.ResponseHeaders.AddHeader(header.Key, header.Value.Value);
+                }
             }
 
             response.HttpVersion = WebSession.Request.HttpVersion;
@@ -501,7 +504,10 @@ namespace Titanium.Web.Proxy.EventArguments
 
             if (headers != null && headers.Count > 0)
             {
-                response.ResponseHeaders = headers;
+                foreach (var header in headers)
+                {
+                    response.ResponseHeaders.AddHeader(header.Key, header.Value.Value);
+                }
             }
 
             response.HttpVersion = WebSession.Request.HttpVersion;
@@ -523,7 +529,7 @@ namespace Titanium.Web.Proxy.EventArguments
             var response = new RedirectResponse();
 
             response.HttpVersion = WebSession.Request.HttpVersion;
-            response.ResponseHeaders.Add("Location", new HttpHeader("Location", url));
+            response.ResponseHeaders.AddHeader("Location", url);
             response.ResponseBody = Encoding.ASCII.GetBytes(string.Empty);
 
             await Respond(response);

--- a/Titanium.Web.Proxy/EventArguments/TunnelConnectEventArgs.cs
+++ b/Titanium.Web.Proxy/EventArguments/TunnelConnectEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Titanium.Web.Proxy.Http;
+
+namespace Titanium.Web.Proxy.EventArguments
+{
+    public class TunnelConnectEventArgs : EventArgs
+    {
+        public bool IsHttps { get; set; }
+
+        public Request ConnectRequest { get; set; }
+
+        public Request ConnectResponse { get; set; }
+    }
+}

--- a/Titanium.Web.Proxy/EventArguments/TunnelConnectEventArgs.cs
+++ b/Titanium.Web.Proxy/EventArguments/TunnelConnectEventArgs.cs
@@ -7,12 +7,13 @@ using Titanium.Web.Proxy.Http;
 
 namespace Titanium.Web.Proxy.EventArguments
 {
-    public class TunnelConnectEventArgs : EventArgs
+    public class TunnelConnectSessionEventArgs : SessionEventArgs
     {
         public bool IsHttps { get; set; }
 
-        public Request ConnectRequest { get; set; }
-
-        public Request ConnectResponse { get; set; }
+        public TunnelConnectSessionEventArgs() : base(0, null)
+        {
+            
+        }
     }
 }

--- a/Titanium.Web.Proxy/Http/ConnectRequest.cs
+++ b/Titanium.Web.Proxy/Http/ConnectRequest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Titanium.Web.Proxy.Http
+{
+    public class ConnectRequest : Request
+    {
+    }
+}

--- a/Titanium.Web.Proxy/Http/ConnectResponse.cs
+++ b/Titanium.Web.Proxy/Http/ConnectResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Titanium.Web.Proxy.Http
+{
+    public class ConnectResponse : Response
+    {
+    }
+}

--- a/Titanium.Web.Proxy/Http/HeaderCollection.cs
+++ b/Titanium.Web.Proxy/Http/HeaderCollection.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Titanium.Web.Proxy.Models;
+
+namespace Titanium.Web.Proxy.Http
+{
+    public class HeaderCollection : IEnumerable<HttpHeader>
+    {
+        /// <summary>
+        /// Unique Request header collection
+        /// </summary>
+        public Dictionary<string, HttpHeader> Headers { get; set; }
+
+        /// <summary>
+        /// Non Unique headers
+        /// </summary>
+        public Dictionary<string, List<HttpHeader>> NonUniqueHeaders { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HeaderCollection"/> class.
+        /// </summary>
+        public HeaderCollection()
+        {
+            Headers = new Dictionary<string, HttpHeader>(StringComparer.OrdinalIgnoreCase);
+            NonUniqueHeaders = new Dictionary<string, List<HttpHeader>>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// True if header exists
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public bool HeaderExists(string name)
+        {
+            return Headers.ContainsKey(name) || NonUniqueHeaders.ContainsKey(name);
+        }
+
+        /// <summary>
+        /// Returns all headers with given name if exists
+        /// Returns null if does'nt exist
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public List<HttpHeader> GetHeaders(string name)
+        {
+            if (Headers.ContainsKey(name))
+            {
+                return new List<HttpHeader>
+                {
+                    Headers[name]
+                };
+            }
+            if (NonUniqueHeaders.ContainsKey(name))
+            {
+                return new List<HttpHeader>(NonUniqueHeaders[name]);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns all headers 
+        /// </summary>
+        /// <returns></returns>
+        public List<HttpHeader> GetAllHeaders()
+        {
+            var result = new List<HttpHeader>();
+
+            result.AddRange(Headers.Select(x => x.Value));
+            result.AddRange(NonUniqueHeaders.SelectMany(x => x.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        /// Add a new header with given name and value
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        public void AddHeader(string name, string value)
+        {
+            AddHeader(new HttpHeader(name, value));
+        }
+
+        /// <summary>
+        /// Adds the given header object to Request
+        /// </summary>
+        /// <param name="newHeader"></param>
+        public void AddHeader(HttpHeader newHeader)
+        {
+            if (NonUniqueHeaders.ContainsKey(newHeader.Name))
+            {
+                NonUniqueHeaders[newHeader.Name].Add(newHeader);
+                return;
+            }
+
+            if (Headers.ContainsKey(newHeader.Name))
+            {
+                var existing = Headers[newHeader.Name];
+                Headers.Remove(newHeader.Name);
+
+                NonUniqueHeaders.Add(newHeader.Name, new List<HttpHeader>
+                {
+                    existing,
+                    newHeader
+                });
+            }
+            else
+            {
+                Headers.Add(newHeader.Name, newHeader);
+            }
+        }
+
+        /// <summary>
+        ///  removes all headers with given name
+        /// </summary>
+        /// <param name="headerName"></param>
+        /// <returns>True if header was removed
+        /// False if no header exists with given name</returns>
+        public bool RemoveHeader(string headerName)
+        {
+            bool result = Headers.Remove(headerName);
+
+            // do not convert to '||' expression to avoid lazy evaluation
+            if (NonUniqueHeaders.Remove(headerName))
+            {
+                result = true;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Removes given header object if it exist
+        /// </summary>
+        /// <param name="header">Returns true if header exists and was removed </param>
+        public bool RemoveHeader(HttpHeader header)
+        {
+            if (Headers.ContainsKey(header.Name))
+            {
+                if (Headers[header.Name].Equals(header))
+                {
+                    Headers.Remove(header.Name);
+                    return true;
+                }
+            }
+            else if (NonUniqueHeaders.ContainsKey(header.Name))
+            {
+                if (NonUniqueHeaders[header.Name].RemoveAll(x => x.Equals(header)) > 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal string GetHeaderValueOrNull(string headerName)
+        {
+            HttpHeader header;
+            if (Headers.TryGetValue(headerName, out header))
+            {
+                return header.Value;
+            }
+
+            return null;
+        }
+
+        internal string SetOrAddHeaderValue(string headerName, string value)
+        {
+            HttpHeader header;
+            if (Headers.TryGetValue(headerName, out header))
+            {
+                header.Value = value;
+            }
+            else
+            {
+                Headers.Add(headerName, new HttpHeader(headerName, value));
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>
+        /// An enumerator that can be used to iterate through the collection.
+        /// </returns>
+        public IEnumerator<HttpHeader> GetEnumerator()
+        {
+            return Headers.Values.Concat(NonUniqueHeaders.Values.SelectMany(x => x)).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Titanium.Web.Proxy/Http/HeaderParser.cs
+++ b/Titanium.Web.Proxy/Http/HeaderParser.cs
@@ -8,9 +8,11 @@ namespace Titanium.Web.Proxy.Http
 {
     internal static class HeaderParser
     {
-        internal static async Task ReadHeaders(CustomBinaryReader reader, Dictionary<string, List<HttpHeader>> nonUniqueResponseHeaders,
-            Dictionary<string, HttpHeader> headers)
+        internal static async Task ReadHeaders(CustomBinaryReader reader, HeaderCollection headerCollection)
         {
+            var nonUniqueResponseHeaders = headerCollection.NonUniqueHeaders;
+            var headers = headerCollection.Headers;
+
             string tmpLine;
             while (!string.IsNullOrEmpty(tmpLine = await reader.ReadLineAsync()))
             {

--- a/Titanium.Web.Proxy/Http/HttpWebClient.cs
+++ b/Titanium.Web.Proxy/Http/HttpWebClient.cs
@@ -27,7 +27,7 @@ namespace Titanium.Web.Proxy.Http
         /// <summary>
         /// Headers passed with Connect.
         /// </summary>
-        public List<HttpHeader> ConnectHeaders { get; set; }
+        public ConnectRequest ConnectRequest { get; set; }
 
         /// <summary>
         /// Web Request.
@@ -94,25 +94,11 @@ namespace Titanium.Web.Proxy.Http
                                             $"{ServerConnection.UpStreamHttpProxy.UserName}:{ServerConnection.UpStreamHttpProxy.Password}")));
             }
             //write request headers
-            foreach (var headerItem in Request.RequestHeaders)
+            foreach (var header in Request.RequestHeaders)
             {
-                var header = headerItem.Value;
-                if (headerItem.Key != "Proxy-Authorization")
+                if (header.Name != "Proxy-Authorization")
                 {
                     requestLines.AppendLine($"{header.Name}: {header.Value}");
-                }
-            }
-
-            //write non unique request headers
-            foreach (var headerItem in Request.NonUniqueRequestHeaders)
-            {
-                var headers = headerItem.Value;
-                foreach (var header in headers)
-                {
-                    if (headerItem.Key != "Proxy-Authorization")
-                    {
-                        requestLines.AppendLine($"{header.Name}: {header.Value}");
-                    }
                 }
             }
 
@@ -211,7 +197,7 @@ namespace Titanium.Web.Proxy.Http
             }
 
             //Read the response headers in to unique and non-unique header collections
-            await HeaderParser.ReadHeaders(ServerConnection.StreamReader, Response.NonUniqueResponseHeaders, Response.ResponseHeaders);
+            await HeaderParser.ReadHeaders(ServerConnection.StreamReader, Response.ResponseHeaders);
         }
 
         /// <summary>
@@ -219,7 +205,7 @@ namespace Titanium.Web.Proxy.Http
         /// </summary>
         public void Dispose()
         {
-            ConnectHeaders = null;
+            ConnectRequest = null;
 
             Request.Dispose();
             Response.Dispose();

--- a/Titanium.Web.Proxy/Http/HttpsTools.cs
+++ b/Titanium.Web.Proxy/Http/HttpsTools.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Titanium.Web.Proxy.Helpers;
+
+namespace Titanium.Web.Proxy.Http
+{
+    class HttpsTools
+    {
+        public static async Task<bool> IsClientHello(CustomBufferedStream clientStream)
+        {
+            //detects the HTTPS ClientHello message as it is described in the following url:
+            //https://stackoverflow.com/questions/3897883/how-to-detect-an-incoming-ssl-https-handshake-ssl-wire-format
+
+            int recordType = await clientStream.PeekByteAsync(0);
+            if (recordType == 0x80)
+            {
+                //SSL 2
+                int length = await clientStream.PeekByteAsync(1);
+                if (length < 9)
+                {
+                    // Message body too short.
+                    return false;
+                }
+
+                if (await clientStream.PeekByteAsync(2) != 0x01)
+                {
+                    // should be ClientHello
+                    return false;
+                }
+
+                int majorVersion = await clientStream.PeekByteAsync(3);
+                int minorVersion = await clientStream.PeekByteAsync(4);
+                return true;
+            }
+            else if (recordType == 0x16)
+            {
+                //SSL 3.0 or TLS 1.0, 1.1 and 1.2
+                int majorVersion = await clientStream.PeekByteAsync(1);
+                int minorVersion = await clientStream.PeekByteAsync(2);
+
+                int length1 = await clientStream.PeekByteAsync(3);
+                int length2 = await clientStream.PeekByteAsync(4);
+                int length = (length1 << 8) + length2;
+
+                if (await clientStream.PeekByteAsync(5) != 0x01)
+                {
+                    // should be ClientHello
+                    return false;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Titanium.Web.Proxy/Http/Response.cs
+++ b/Titanium.Web.Proxy/Http/Response.cs
@@ -30,13 +30,7 @@ namespace Titanium.Web.Proxy.Http
         /// <summary>
         /// Content encoding for this response
         /// </summary>
-        public string ContentEncoding
-        {
-            get
-            {
-                return ResponseHeaders.GetHeaderValueOrNull("content-encoding")?.Trim();
-            }
-        }
+        public string ContentEncoding => ResponseHeaders.GetHeaderValueOrNull("content-encoding")?.Trim();
 
         /// <summary>
         /// Http version
@@ -67,13 +61,7 @@ namespace Titanium.Web.Proxy.Http
         /// <summary>
         /// Content type of this response
         /// </summary>
-        public string ContentType
-        {
-            get
-            {
-                return ResponseHeaders.GetHeaderValueOrNull("content-type");
-            }
-        }
+        public string ContentType => ResponseHeaders.GetHeaderValueOrNull("content-type");
 
         /// <summary>
         /// Length of response body

--- a/Titanium.Web.Proxy/Http/Response.cs
+++ b/Titanium.Web.Proxy/Http/Response.cs
@@ -34,13 +34,7 @@ namespace Titanium.Web.Proxy.Http
         {
             get
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("content-encoding");
-
-                if (!hasHeader)
-                    return null;
-                var header = ResponseHeaders["content-encoding"];
-
-                return header.Value.Trim();
+                return ResponseHeaders.GetHeaderValueOrNull("content-encoding")?.Trim();
             }
         }
 
@@ -56,13 +50,11 @@ namespace Titanium.Web.Proxy.Http
         {
             get
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("connection");
+                string headerValue = ResponseHeaders.GetHeaderValueOrNull("connection");
 
-                if (hasHeader)
+                if (headerValue != null)
                 {
-                    var header = ResponseHeaders["connection"];
-
-                    if (header.Value.ContainsIgnoreCase("close"))
+                    if (headerValue.ContainsIgnoreCase("close"))
                     {
                         return false;
                     }
@@ -79,16 +71,7 @@ namespace Titanium.Web.Proxy.Http
         {
             get
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("content-type");
-
-                if (hasHeader)
-                {
-                    var header = ResponseHeaders["content-type"];
-
-                    return header.Value;
-                }
-
-                return null;
+                return ResponseHeaders.GetHeaderValueOrNull("content-type");
             }
         }
 
@@ -99,17 +82,15 @@ namespace Titanium.Web.Proxy.Http
         {
             get
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("content-length");
+                string headerValue = ResponseHeaders.GetHeaderValueOrNull("content-length");
 
-                if (hasHeader == false)
+                if (headerValue == null)
                 {
                     return -1;
                 }
 
-                var header = ResponseHeaders["content-length"];
-
                 long contentLen;
-                long.TryParse(header.Value, out contentLen);
+                long.TryParse(headerValue, out contentLen);
                 if (contentLen >= 0)
                 {
                     return contentLen;
@@ -119,28 +100,14 @@ namespace Titanium.Web.Proxy.Http
             }
             set
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("content-length");
-
                 if (value >= 0)
                 {
-                    if (hasHeader)
-                    {
-                        var header = ResponseHeaders["content-length"];
-                        header.Value = value.ToString();
-                    }
-                    else
-                    {
-                        ResponseHeaders.Add("content-length", new HttpHeader("content-length", value.ToString()));
-                    }
-
+                    ResponseHeaders.SetOrAddHeaderValue("content-length", value.ToString());
                     IsChunked = false;
                 }
                 else
                 {
-                    if (hasHeader)
-                    {
-                        ResponseHeaders.Remove("content-length");
-                    }
+                    ResponseHeaders.RemoveHeader("content-length");
                 }
             }
         }
@@ -152,44 +119,19 @@ namespace Titanium.Web.Proxy.Http
         {
             get
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("transfer-encoding");
-
-                if (hasHeader)
-                {
-                    var header = ResponseHeaders["transfer-encoding"];
-
-                    if (header.Value.ContainsIgnoreCase("chunked"))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
+                string headerValue = ResponseHeaders.GetHeaderValueOrNull("transfer-encoding");
+                return headerValue != null && headerValue.ContainsIgnoreCase("chunked");
             }
             set
             {
-                bool hasHeader = ResponseHeaders.ContainsKey("transfer-encoding");
-
                 if (value)
                 {
-                    if (hasHeader)
-                    {
-                        var header = ResponseHeaders["transfer-encoding"];
-                        header.Value = "chunked";
-                    }
-                    else
-                    {
-                        ResponseHeaders.Add("transfer-encoding", new HttpHeader("transfer-encoding", "chunked"));
-                    }
-
+                    ResponseHeaders.SetOrAddHeaderValue("transfer-encoding", "chunked");
                     ContentLength = -1;
                 }
                 else
                 {
-                    if (hasHeader)
-                    {
-                        ResponseHeaders.Remove("transfer-encoding");
-                    }
+                    ResponseHeaders.RemoveHeader("transfer-encoding");
                 }
             }
         }
@@ -197,12 +139,7 @@ namespace Titanium.Web.Proxy.Http
         /// <summary>
         /// Collection of all response headers
         /// </summary>
-        public Dictionary<string, HttpHeader> ResponseHeaders { get; set; }
-
-        /// <summary>
-        /// Non Unique headers
-        /// </summary>
-        public Dictionary<string, List<HttpHeader>> NonUniqueResponseHeaders { get; set; }
+        public HeaderCollection ResponseHeaders { get; set; }
 
         /// <summary>
         /// response body content as byte array
@@ -239,146 +176,7 @@ namespace Titanium.Web.Proxy.Http
         /// </summary>
         public Response()
         {
-            ResponseHeaders = new Dictionary<string, HttpHeader>(StringComparer.OrdinalIgnoreCase);
-            NonUniqueResponseHeaders = new Dictionary<string, List<HttpHeader>>(StringComparer.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// True if header exists
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public bool HeaderExists(string name)
-        {
-            if (ResponseHeaders.ContainsKey(name) || NonUniqueResponseHeaders.ContainsKey(name))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Returns all headers with given name if exists
-        /// Returns null if does'nt exist
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public List<HttpHeader> GetHeaders(string name)
-        {
-            if (ResponseHeaders.ContainsKey(name))
-            {
-                return new List<HttpHeader>
-                {
-                    ResponseHeaders[name]
-                };
-            }
-            if (NonUniqueResponseHeaders.ContainsKey(name))
-            {
-                return new List<HttpHeader>(NonUniqueResponseHeaders[name]);
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Returns all headers 
-        /// </summary>
-        /// <returns></returns>
-        public List<HttpHeader> GetAllHeaders()
-        {
-            var result = new List<HttpHeader>();
-
-            result.AddRange(ResponseHeaders.Select(x => x.Value));
-            result.AddRange(NonUniqueResponseHeaders.SelectMany(x => x.Value));
-
-            return result;
-        }
-
-        /// <summary>
-        /// Add a new header with given name and value
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="value"></param>
-        public void AddHeader(string name, string value)
-        {
-            AddHeader(new HttpHeader(name, value));
-        }
-
-        /// <summary>
-        /// Adds the given header object to Response
-        /// </summary>
-        /// <param name="newHeader"></param>
-        public void AddHeader(HttpHeader newHeader)
-        {
-            if (NonUniqueResponseHeaders.ContainsKey(newHeader.Name))
-            {
-                NonUniqueResponseHeaders[newHeader.Name].Add(newHeader);
-                return;
-            }
-
-            if (ResponseHeaders.ContainsKey(newHeader.Name))
-            {
-                var existing = ResponseHeaders[newHeader.Name];
-                ResponseHeaders.Remove(newHeader.Name);
-
-                NonUniqueResponseHeaders.Add(newHeader.Name, new List<HttpHeader>
-                {
-                    existing,
-                    newHeader
-                });
-            }
-            else
-            {
-                ResponseHeaders.Add(newHeader.Name, newHeader);
-            }
-        }
-
-        /// <summary>
-        ///  removes all headers with given name
-        /// </summary>
-        /// <param name="headerName"></param>
-        /// <returns>True if header was removed
-        /// False if no header exists with given name</returns>
-        public bool RemoveHeader(string headerName)
-        {
-            if (ResponseHeaders.ContainsKey(headerName))
-            {
-                ResponseHeaders.Remove(headerName);
-                return true;
-            }
-            if (NonUniqueResponseHeaders.ContainsKey(headerName))
-            {
-                NonUniqueResponseHeaders.Remove(headerName);
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Removes given header object if it exist
-        /// </summary>
-        /// <param name="header">Returns true if header exists and was removed </param>
-        public bool RemoveHeader(HttpHeader header)
-        {
-            if (ResponseHeaders.ContainsKey(header.Name))
-            {
-                if (ResponseHeaders[header.Name].Equals(header))
-                {
-                    ResponseHeaders.Remove(header.Name);
-                    return true;
-                }
-            }
-            else if (NonUniqueResponseHeaders.ContainsKey(header.Name))
-            {
-                if (NonUniqueResponseHeaders[header.Name].RemoveAll(x => x.Equals(header)) > 0)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            ResponseHeaders = new HeaderCollection();
         }
 
         /// <summary>
@@ -390,7 +188,6 @@ namespace Titanium.Web.Proxy.Http
             //but just to be on safe side
 
             ResponseHeaders = null;
-            NonUniqueResponseHeaders = null;
 
             ResponseBody = null;
             ResponseBodyString = null;

--- a/Titanium.Web.Proxy/Models/EndPoint.cs
+++ b/Titanium.Web.Proxy/Models/EndPoint.cs
@@ -53,6 +53,7 @@ namespace Titanium.Web.Proxy.Models
         public bool IpV6Enabled => Equals(IpAddress, IPAddress.IPv6Any)
                                    || Equals(IpAddress, IPAddress.IPv6Loopback)
                                    || Equals(IpAddress, IPAddress.IPv6None);
+
     }
 
     /// <summary>
@@ -67,12 +68,6 @@ namespace Titanium.Web.Proxy.Models
         internal bool IsSystemHttpProxy { get; set; }
 
         internal bool IsSystemHttpsProxy { get; set; }
-
-        /// <summary>
-        /// Remote HTTPS ports we are allowed to communicate with
-        /// CONNECT request to ports other than these will not be decrypted
-        /// </summary>
-        public List<int> RemoteHttpsPorts { get; set; }
 
         /// <summary>
         /// List of host names to exclude using Regular Expressions.
@@ -121,12 +116,6 @@ namespace Titanium.Web.Proxy.Models
         /// <param name="enableSsl"></param>
         public ExplicitProxyEndPoint(IPAddress ipAddress, int port, bool enableSsl) : base(ipAddress, port, enableSsl)
         {
-            //init to well known HTTPS ports
-            RemoteHttpsPorts = new List<int>
-            {
-                443,
-                8443
-            };
         }
     }
 

--- a/Titanium.Web.Proxy/Network/Tcp/TcpConnection.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpConnection.cs
@@ -15,11 +15,15 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
         internal ExternalProxy UpStreamHttpsProxy { get; set; }
 
+        internal ExternalProxy UpStreamProxy => UseProxy ? IsHttps ? UpStreamHttpsProxy : UpStreamHttpProxy : null;
+
         internal string HostName { get; set; }
 
         internal int Port { get; set; }
 
         internal bool IsHttps { get; set; }
+
+        internal bool UseProxy { get; set; }
 
         /// <summary>
         /// Http version

--- a/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -32,29 +32,18 @@ namespace Titanium.Web.Proxy.Network.Tcp
         internal async Task<TcpConnection> CreateClient(ProxyServer server, string remoteHostName, int remotePort, Version httpVersion, bool isHttps,
             ExternalProxy externalHttpProxy, ExternalProxy externalHttpsProxy)
         {
-            bool useHttpProxy = false;
-            //check if external proxy is set for HTTP
-            if (!isHttps && externalHttpProxy != null && !(externalHttpProxy.HostName == remoteHostName && externalHttpProxy.Port == remotePort))
+            bool useProxy = false;
+            var externalProxy = isHttps ? externalHttpsProxy : externalHttpProxy;
+
+            //check if external proxy is set for HTTP/HTTPS
+            if (externalProxy != null && !(externalProxy.HostName == remoteHostName && externalProxy.Port == remotePort))
             {
-                useHttpProxy = true;
+                useProxy = true;
 
                 //check if we need to ByPass
-                if (externalHttpProxy.BypassLocalhost && NetworkHelper.IsLocalIpAddress(remoteHostName))
+                if (externalProxy.BypassLocalhost && NetworkHelper.IsLocalIpAddress(remoteHostName))
                 {
-                    useHttpProxy = false;
-                }
-            }
-
-            bool useHttpsProxy = false;
-            //check if external proxy is set for HTTPS
-            if (isHttps && externalHttpsProxy != null && !(externalHttpsProxy.HostName == remoteHostName && externalHttpsProxy.Port == remotePort))
-            {
-                useHttpsProxy = true;
-
-                //check if we need to ByPass
-                if (externalHttpsProxy.BypassLocalhost && NetworkHelper.IsLocalIpAddress(remoteHostName))
-                {
-                    useHttpsProxy = false;
+                    useProxy = false;
                 }
             }
 
@@ -63,74 +52,59 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
             try
             {
+                //If this proxy uses another external proxy then create a tunnel request for HTTP/HTTPS connections
+                if (useProxy)
+                {
+                    client = new TcpClient(server.UpStreamEndPoint);
+                    await client.ConnectAsync(externalProxy.HostName, externalProxy.Port);
+                    stream = new CustomBufferedStream(client.GetStream(), server.BufferSize);
+
+                    using (var writer = new StreamWriter(stream, Encoding.ASCII, server.BufferSize, true)
+                    {
+                        NewLine = ProxyConstants.NewLine
+                    })
+                    {
+                        await writer.WriteLineAsync($"CONNECT {remoteHostName}:{remotePort} HTTP/{httpVersion}");
+                        await writer.WriteLineAsync($"Host: {remoteHostName}:{remotePort}");
+                        await writer.WriteLineAsync("Connection: Keep-Alive");
+
+                        if (!string.IsNullOrEmpty(externalProxy.UserName) && externalProxy.Password != null)
+                        {
+                            await writer.WriteLineAsync("Proxy-Connection: keep-alive");
+                            await writer.WriteLineAsync("Proxy-Authorization" + ": Basic " +
+                                                        Convert.ToBase64String(Encoding.UTF8.GetBytes(
+                                                            externalProxy.UserName + ":" + externalProxy.Password)));
+                        }
+                        await writer.WriteLineAsync();
+                        await writer.FlushAsync();
+                        writer.Close();
+                    }
+
+                    using (var reader = new CustomBinaryReader(stream, server.BufferSize))
+                    {
+                        string result = await reader.ReadLineAsync();
+
+                        if (!new[] { "200 OK", "connection established" }.Any(s => result.ContainsIgnoreCase(s)))
+                        {
+                            throw new Exception("Upstream proxy failed to create a secure tunnel");
+                        }
+
+                        await reader.ReadAndIgnoreAllLinesAsync();
+                    }
+                }
+                else
+                {
+                    client = new TcpClient(server.UpStreamEndPoint);
+                    await client.ConnectAsync(remoteHostName, remotePort);
+                    stream = new CustomBufferedStream(client.GetStream(), server.BufferSize);
+                }
+
                 if (isHttps)
                 {
-                    //If this proxy uses another external proxy then create a tunnel request for HTTPS connections
-                    if (useHttpsProxy)
-                    {
-                        client = new TcpClient(server.UpStreamEndPoint);
-                        await client.ConnectAsync(externalHttpsProxy.HostName, externalHttpsProxy.Port);
-                        stream = new CustomBufferedStream(client.GetStream(), server.BufferSize);
-
-                        using (var writer = new StreamWriter(stream, Encoding.ASCII, server.BufferSize, true)
-                        {
-                            NewLine = ProxyConstants.NewLine
-                        })
-                        {
-                            await writer.WriteLineAsync($"CONNECT {remoteHostName}:{remotePort} HTTP/{httpVersion}");
-                            await writer.WriteLineAsync($"Host: {remoteHostName}:{remotePort}");
-                            await writer.WriteLineAsync("Connection: Keep-Alive");
-
-                            if (!string.IsNullOrEmpty(externalHttpsProxy.UserName) && externalHttpsProxy.Password != null)
-                            {
-                                await writer.WriteLineAsync("Proxy-Connection: keep-alive");
-                                await writer.WriteLineAsync("Proxy-Authorization" + ": Basic " +
-                                                            Convert.ToBase64String(Encoding.UTF8.GetBytes(
-                                                                externalHttpsProxy.UserName + ":" + externalHttpsProxy.Password)));
-                            }
-                            await writer.WriteLineAsync();
-                            await writer.FlushAsync();
-                            writer.Close();
-                        }
-
-                        using (var reader = new CustomBinaryReader(stream, server.BufferSize))
-                        {
-                            string result = await reader.ReadLineAsync();
-
-                            if (!new[] { "200 OK", "connection established" }.Any(s => result.ContainsIgnoreCase(s)))
-                            {
-                                throw new Exception("Upstream proxy failed to create a secure tunnel");
-                            }
-
-                            await reader.ReadAndIgnoreAllLinesAsync();
-                        }
-                    }
-                    else
-                    {
-                        client = new TcpClient(server.UpStreamEndPoint);
-                        await client.ConnectAsync(remoteHostName, remotePort);
-                        stream = new CustomBufferedStream(client.GetStream(), server.BufferSize);
-                    }
-
                     var sslStream = new SslStream(stream, false, server.ValidateServerCertificate, server.SelectClientCertificate);
                     stream = new CustomBufferedStream(sslStream, server.BufferSize);
 
                     await sslStream.AuthenticateAsClientAsync(remoteHostName, null, server.SupportedSslProtocols, server.CheckCertificateRevocation);
-                }
-                else
-                {
-                    if (useHttpProxy)
-                    {
-                        client = new TcpClient(server.UpStreamEndPoint);
-                        await client.ConnectAsync(externalHttpProxy.HostName, externalHttpProxy.Port);
-                        stream = new CustomBufferedStream(client.GetStream(), server.BufferSize);
-                    }
-                    else
-                    {
-                        client = new TcpClient(server.UpStreamEndPoint);
-                        await client.ConnectAsync(remoteHostName, remotePort);
-                        stream = new CustomBufferedStream(client.GetStream(), server.BufferSize);
-                    }
                 }
 
                 client.ReceiveTimeout = server.ConnectionTimeOutSeconds * 1000;
@@ -152,6 +126,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 HostName = remoteHostName,
                 Port = remotePort,
                 IsHttps = isHttps,
+                UseProxy = useProxy,
                 TcpClient = client,
                 StreamReader = new CustomBinaryReader(stream, server.BufferSize),
                 Stream = stream,

--- a/Titanium.Web.Proxy/ProxyAuthorizationHandler.cs
+++ b/Titanium.Web.Proxy/ProxyAuthorizationHandler.cs
@@ -12,14 +12,14 @@ namespace Titanium.Web.Proxy
 {
     public partial class ProxyServer
     {
-        private async Task<bool> CheckAuthorization(StreamWriter clientStreamWriter, IEnumerable<HttpHeader> headers)
+        private async Task<bool> CheckAuthorization(StreamWriter clientStreamWriter, Request request)
         {
             if (AuthenticateUserFunc == null)
             {
                 return true;
             }
 
-            var httpHeaders = headers as ICollection<HttpHeader> ?? headers.ToArray();
+            var httpHeaders = request.RequestHeaders.ToArray();
 
             try
             {
@@ -67,14 +67,10 @@ namespace Titanium.Web.Proxy
         private async Task SendAuthentication407Response(StreamWriter clientStreamWriter, string description)
         {
             await WriteResponseStatus(HttpHeader.Version11, "407", description, clientStreamWriter);
-            var response = new Response
-            {
-                ResponseHeaders = new Dictionary<string, HttpHeader>
-                {
-                    { "Proxy-Authenticate", new HttpHeader("Proxy-Authenticate", "Basic realm=\"TitaniumProxy\"") },
-                    { "Proxy-Connection", new HttpHeader("Proxy-Connection", "close") }
-                }
-            };
+            var response = new Response();
+            response.ResponseHeaders.AddHeader("Proxy-Authenticate", "Basic realm=\"TitaniumProxy\"");
+            response.ResponseHeaders.AddHeader("Proxy-Connection", "close");
+
             await WriteResponseHeaders(clientStreamWriter, response);
 
             await clientStreamWriter.WriteLineAsync();

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -172,9 +172,15 @@ namespace Titanium.Web.Proxy
         /// </summary>
         public event Func<object, SessionEventArgs, Task> BeforeResponse;
 
-        public event Func<object, TunnelConnectEventArgs, Task> TunnelConnectRequest;
+        /// <summary>
+        /// Intercept tunnel connect reques
+        /// </summary>
+        public event Func<object, TunnelConnectSessionEventArgs, Task> TunnelConnectRequest;
 
-        public event Func<object, TunnelConnectEventArgs, Task> TunnelConnectResponse;
+        /// <summary>
+        /// Intercept tunnel connect response
+        /// </summary>
+        public event Func<object, TunnelConnectSessionEventArgs, Task> TunnelConnectResponse;
 
         /// <summary>
         /// External proxy for Http

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -172,6 +172,10 @@ namespace Titanium.Web.Proxy
         /// </summary>
         public event Func<object, SessionEventArgs, Task> BeforeResponse;
 
+        public event Func<object, TunnelConnectEventArgs, Task> TunnelConnectRequest;
+
+        public event Func<object, TunnelConnectEventArgs, Task> TunnelConnectResponse;
+
         /// <summary>
         /// External proxy for Http
         /// </summary>

--- a/Titanium.Web.Proxy/RequestHandler.cs
+++ b/Titanium.Web.Proxy/RequestHandler.cs
@@ -109,14 +109,9 @@ namespace Titanium.Web.Proxy
                         excluded = true;   
                     }
 
-                    if (!excluded)
+                    if (!excluded && await CheckAuthorization(clientStreamWriter, connectRequestHeaders) == false)
                     {
-                        if (await CheckAuthorization(clientStreamWriter, connectRequestHeaders) == false)
-                        {
-                            return;
-                        }
-
-                        httpRemoteUri = new Uri("https://" + httpCmdSplit[1]);
+                        return;
                     }
 
                     //write back successfull CONNECT response
@@ -129,6 +124,8 @@ namespace Titanium.Web.Proxy
 
                     if (!excluded)
                     {
+                        httpRemoteUri = new Uri("https://" + httpCmdSplit[1]);
+
                         SslStream sslStream = null;
 
                         try

--- a/Titanium.Web.Proxy/ResponseHandler.cs
+++ b/Titanium.Web.Proxy/ResponseHandler.cs
@@ -174,17 +174,7 @@ namespace Titanium.Web.Proxy
 
             foreach (var header in response.ResponseHeaders)
             {
-                await header.Value.WriteToStream(responseWriter);
-            }
-
-            //write non unique request headers
-            foreach (var headerItem in response.NonUniqueResponseHeaders)
-            {
-                var headers = headerItem.Value;
-                foreach (var header in headers)
-                {
-                    await header.WriteToStream(responseWriter);
-                }
+                await header.WriteToStream(responseWriter);
             }
 
             await responseWriter.WriteLineAsync();
@@ -195,26 +185,15 @@ namespace Titanium.Web.Proxy
         /// Fix proxy specific headers
         /// </summary>
         /// <param name="headers"></param>
-        private void FixProxyHeaders(Dictionary<string, HttpHeader> headers)
+        private void FixProxyHeaders(HeaderCollection headers)
         {
             //If proxy-connection close was returned inform to close the connection
-            bool hasProxyHeader = headers.ContainsKey("proxy-connection");
-            bool hasConnectionheader = headers.ContainsKey("connection");
+            string proxyHeader = headers.GetHeaderValueOrNull("proxy-connection");
+            headers.RemoveHeader("proxy-connection");
 
-            if (hasProxyHeader)
+            if (proxyHeader != null)
             {
-                var proxyHeader = headers["proxy-connection"];
-                if (hasConnectionheader == false)
-                {
-                    headers.Add("connection", new HttpHeader("connection", proxyHeader.Value));
-                }
-                else
-                {
-                    var connectionHeader = headers["connection"];
-                    connectionHeader.Value = proxyHeader.Value;
-                }
-
-                headers.Remove("proxy-connection");
+                headers.SetOrAddHeaderValue("connection", proxyHeader);
             }
         }
 

--- a/Titanium.Web.Proxy/ResponseHandler.cs
+++ b/Titanium.Web.Proxy/ResponseHandler.cs
@@ -150,6 +150,19 @@ namespace Titanium.Web.Proxy
         }
 
         /// <summary>
+        /// Writes the response.
+        /// </summary>
+        /// <param name="response"></param>
+        /// <param name="responseWriter"></param>
+        /// <param name="flush"></param>
+        /// <returns></returns>
+        private async Task WriteResponse(Response response, StreamWriter responseWriter, bool flush = true)
+        {
+            await WriteResponseStatus(response.HttpVersion, response.ResponseStatusCode, response.ResponseStatusDescription, responseWriter);
+            await WriteResponseHeaders(responseWriter, response, flush);
+        }
+
+        /// <summary>
         /// Write response status
         /// </summary>
         /// <param name="version"></param>
@@ -167,8 +180,9 @@ namespace Titanium.Web.Proxy
         /// </summary>
         /// <param name="responseWriter"></param>
         /// <param name="response"></param>
+        /// <param name="flush"></param>
         /// <returns></returns>
-        private async Task WriteResponseHeaders(StreamWriter responseWriter, Response response)
+        private async Task WriteResponseHeaders(StreamWriter responseWriter, Response response, bool flush = true)
         {
             FixProxyHeaders(response.ResponseHeaders);
 
@@ -178,7 +192,10 @@ namespace Titanium.Web.Proxy
             }
 
             await responseWriter.WriteLineAsync();
-            await responseWriter.FlushAsync();
+            if (flush)
+            {
+                await responseWriter.FlushAsync();
+            }
         }
 
         /// <summary>

--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Helpers\WinHttp\WinHttpHandle.cs" />
     <Compile Include="Helpers\WinHttp\WinHttpWebProxyFinder.cs" />
     <Compile Include="Http\HeaderParser.cs" />
+    <Compile Include="Http\HttpsTools.cs" />
     <Compile Include="Http\Responses\GenericResponse.cs" />
     <Compile Include="Network\CachedCertificate.cs" />
     <Compile Include="Network\Certificate\WinCertificateMaker.cs" />

--- a/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Decompression\IDecompression.cs" />
     <Compile Include="EventArguments\CertificateSelectionEventArgs.cs" />
     <Compile Include="EventArguments\CertificateValidationEventArgs.cs" />
+    <Compile Include="EventArguments\TunnelConnectEventArgs.cs" />
     <Compile Include="Extensions\ByteArrayExtensions.cs" />
     <Compile Include="Extensions\FuncExtensions.cs" />
     <Compile Include="Helpers\HttpHelper.cs" />
@@ -85,6 +86,9 @@
     <Compile Include="Helpers\RunTime.cs" />
     <Compile Include="Helpers\WinHttp\WinHttpHandle.cs" />
     <Compile Include="Helpers\WinHttp\WinHttpWebProxyFinder.cs" />
+    <Compile Include="Http\ConnectRequest.cs" />
+    <Compile Include="Http\ConnectResponse.cs" />
+    <Compile Include="Http\HeaderCollection.cs" />
     <Compile Include="Http\HeaderParser.cs" />
     <Compile Include="Http\HttpsTools.cs" />
     <Compile Include="Http\Responses\GenericResponse.cs" />

--- a/Titanium.Web.Proxy/WinAuthHandler.cs
+++ b/Titanium.Web.Proxy/WinAuthHandler.cs
@@ -44,7 +44,7 @@ namespace Titanium.Web.Proxy
 
             //check in non-unique headers first
             var header =
-                args.WebSession.Response.NonUniqueResponseHeaders.FirstOrDefault(
+                args.WebSession.Response.ResponseHeaders.NonUniqueHeaders.FirstOrDefault(
                     x => authHeaderNames.Any(y => x.Key.Equals(y, StringComparison.OrdinalIgnoreCase)));
 
             if (!header.Equals(new KeyValuePair<string, List<HttpHeader>>()))
@@ -54,7 +54,7 @@ namespace Titanium.Web.Proxy
 
             if (headerName != null)
             {
-                authHeader = args.WebSession.Response.NonUniqueResponseHeaders[headerName]
+                authHeader = args.WebSession.Response.ResponseHeaders.NonUniqueHeaders[headerName]
                     .FirstOrDefault(x => authSchemes.Any(y => x.Value.StartsWith(y, StringComparison.OrdinalIgnoreCase)));
             }
 
@@ -63,7 +63,7 @@ namespace Titanium.Web.Proxy
             {
                 //check in non-unique headers first
                 var uHeader =
-                    args.WebSession.Response.ResponseHeaders.FirstOrDefault(x => authHeaderNames.Any(y => x.Key.Equals(y, StringComparison.OrdinalIgnoreCase)));
+                    args.WebSession.Response.ResponseHeaders.Headers.FirstOrDefault(x => authHeaderNames.Any(y => x.Key.Equals(y, StringComparison.OrdinalIgnoreCase)));
 
                 if (!uHeader.Equals(new KeyValuePair<string, HttpHeader>()))
                 {
@@ -72,9 +72,9 @@ namespace Titanium.Web.Proxy
 
                 if (headerName != null)
                 {
-                    authHeader = authSchemes.Any(x => args.WebSession.Response.ResponseHeaders[headerName].Value
+                    authHeader = authSchemes.Any(x => args.WebSession.Response.ResponseHeaders.Headers[headerName].Value
                         .StartsWith(x, StringComparison.OrdinalIgnoreCase))
-                        ? args.WebSession.Response.ResponseHeaders[headerName]
+                        ? args.WebSession.Response.ResponseHeaders.Headers[headerName]
                         : null;
                 }
             }
@@ -84,9 +84,9 @@ namespace Titanium.Web.Proxy
                 string scheme = authSchemes.FirstOrDefault(x => authHeader.Value.Equals(x, StringComparison.OrdinalIgnoreCase));
 
                 //clear any existing headers to avoid confusing bad servers
-                if (args.WebSession.Request.NonUniqueRequestHeaders.ContainsKey("Authorization"))
+                if (args.WebSession.Request.RequestHeaders.NonUniqueHeaders.ContainsKey("Authorization"))
                 {
-                    args.WebSession.Request.NonUniqueRequestHeaders.Remove("Authorization");
+                    args.WebSession.Request.RequestHeaders.NonUniqueHeaders.Remove("Authorization");
                 }
 
                 //initial value will match exactly any of the schemes
@@ -97,13 +97,13 @@ namespace Titanium.Web.Proxy
                     var auth = new HttpHeader("Authorization", string.Concat(scheme, clientToken));
 
                     //replace existing authorization header if any
-                    if (args.WebSession.Request.RequestHeaders.ContainsKey("Authorization"))
+                    if (args.WebSession.Request.RequestHeaders.Headers.ContainsKey("Authorization"))
                     {
-                        args.WebSession.Request.RequestHeaders["Authorization"] = auth;
+                        args.WebSession.Request.RequestHeaders.Headers["Authorization"] = auth;
                     }
                     else
                     {
-                        args.WebSession.Request.RequestHeaders.Add("Authorization", auth);
+                        args.WebSession.Request.RequestHeaders.Headers.Add("Authorization", auth);
                     }
 
                     //don't need to send body for Authorization request
@@ -122,7 +122,7 @@ namespace Titanium.Web.Proxy
                     string clientToken = WinAuthHandler.GetFinalAuthToken(args.WebSession.Request.Host, serverToken, args.Id);
 
                     //there will be an existing header from initial client request 
-                    args.WebSession.Request.RequestHeaders["Authorization"] = new HttpHeader("Authorization", string.Concat(scheme, clientToken));
+                    args.WebSession.Request.RequestHeaders.Headers["Authorization"] = new HttpHeader("Authorization", string.Concat(scheme, clientToken));
 
                     //send body for final auth request
                     if (args.WebSession.Request.HasBody)


### PR DESCRIPTION
- Using upstream proxy when host is excluded, too (earlier upstream proxy was ignored in this case which is wrong)

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 

I tried to test it carefully with HTTP site, excluded HTTPS site and non excluded HTTPS site. With and without upstream proxy. It seems to work now in all cases. I hope there is no bug... or at least better then earlier:)
