### PR TITLE
Fixes connection blocking issues on Android emulators

### DIFF
--- a/Titanium.Web.Proxy/Http/ConnectResponse.cs
+++ b/Titanium.Web.Proxy/Http/ConnectResponse.cs
@@ -22,7 +22,6 @@ namespace Titanium.Web.Proxy.Http
                 StatusDescription = "Connection Established"
             };
 
-            response.Headers.AddHeader(KnownHeaders.Timestamp, DateTime.Now.ToString());
             return response;
         }
     }

--- a/Titanium.Web.Proxy/Http/KnownHeaders.cs
+++ b/Titanium.Web.Proxy/Http/KnownHeaders.cs
@@ -47,8 +47,5 @@ namespace Titanium.Web.Proxy.Http
 
         public const string TransferEncoding = "transfer-encoding";
         public const string TransferEncodingChunked = "chunked";
-
-        // ???
-        public const string Timestamp = "Timestamp";
     }
 }


### PR DESCRIPTION
Fixes connection blocking issues on Android emulators caused by adding not-needed Timestamp HTTP Header set on the CONNECT response.

I've tested the fix on Android, Mac and iOS - no issues have been found.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
