### PR TITLE
Added ability to inject a custom authentication mechanism

### DIFF
--- a/Titanium.Web.Proxy/Models/ProxyAuthenticationContext.cs
+++ b/Titanium.Web.Proxy/Models/ProxyAuthenticationContext.cs
@@ -1,0 +1,53 @@
+﻿namespace Titanium.Web.Proxy.Models
+{
+    public enum ProxyAuthenticationResult
+    {
+        /// <summary>
+        /// Indicates the authentication request was successful
+        /// </summary>
+        Success,
+        /// <summary>
+        /// Indicates the authentication request failed
+        /// </summary>
+        Failure,
+        /// <summary>
+        /// Indicates that this stage of the authentication request succeeded
+        /// And a second pass of the handshake needs to occur
+        /// </summary>
+        ContinuationNeeded
+    }
+
+    /// <summary>
+    /// A context container for authentication flows
+    /// </summary>
+    public class ProxyAuthenticationContext
+    {
+        /// <summary>
+        /// The result of the current authentication request
+        /// </summary>
+        public ProxyAuthenticationResult Result { get; set; }
+
+        /// <summary>
+        /// An optional continuation token to return to the caller if set
+        /// </summary>
+        public string Continuation { get; set; }
+
+        public static ProxyAuthenticationContext Failed()
+        {
+            return new ProxyAuthenticationContext
+            {
+                Result = ProxyAuthenticationResult.Failure,
+                Continuation = null
+            };
+        }
+
+        public static ProxyAuthenticationContext Succeeded()
+        {
+            return new ProxyAuthenticationContext
+            {
+                Result = ProxyAuthenticationResult.Success,
+                Continuation = null
+            };
+        }
+    }
+}

--- a/Titanium.Web.Proxy/ProxyAuthorizationHandler.cs
+++ b/Titanium.Web.Proxy/ProxyAuthorizationHandler.cs
@@ -21,7 +21,7 @@ namespace Titanium.Web.Proxy
         private async Task<bool> checkAuthorization(SessionEventArgsBase session)
         {
             // If we are not authorizing clients return true
-            if (AuthenticateUserFunc == null)
+            if (AuthenticateUserFunc == null && AuthenticateSchemeFunc == null)
             {
                 return true;
             }
@@ -38,32 +38,34 @@ namespace Titanium.Web.Proxy
                 }
 
                 var headerValueParts = header.Value.Split(ProxyConstants.SpaceSplit);
-                if (headerValueParts.Length != 2 ||
-                    !headerValueParts[0].EqualsIgnoreCase(KnownHeaders.ProxyAuthorizationBasic))
+
+                if (headerValueParts.Length != 2)
                 {
                     // Return not authorized
                     session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid");
                     return false;
                 }
 
-                string decoded = Encoding.UTF8.GetString(Convert.FromBase64String(headerValueParts[1]));
-                int colonIndex = decoded.IndexOf(':');
-                if (colonIndex == -1)
+                if (AuthenticateUserFunc != null)
                 {
-                    // Return not authorized
-                    session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid");
-                    return false;
+                    return await authenticateUserBasic(session, headerValueParts);
                 }
 
-                string username = decoded.Substring(0, colonIndex);
-                string password = decoded.Substring(colonIndex + 1);
-                bool authenticated = await AuthenticateUserFunc(username, password);
-                if (!authenticated)
+                if (AuthenticateSchemeFunc != null)
                 {
-                    session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid");
+                    var result = await AuthenticateSchemeFunc(session, headerValueParts[0], headerValueParts[1]);
+
+                    if (result.Result == ProxyAuthenticationResult.ContinuationNeeded)
+                    {
+                        session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid", result.Continuation);
+
+                        return false;
+                    }
+
+                    return result.Result == ProxyAuthenticationResult.Success;
                 }
 
-                return authenticated;
+                return false;
             }
             catch (Exception e)
             {
@@ -76,12 +78,41 @@ namespace Titanium.Web.Proxy
             }
         }
 
+        private async Task<bool> authenticateUserBasic(SessionEventArgsBase session, string[] headerValueParts)
+        {
+            if (!headerValueParts[0].EqualsIgnoreCase(KnownHeaders.ProxyAuthorizationBasic))
+            {
+                // Return not authorized
+                session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid");
+                return false;
+            }
+
+            string decoded = Encoding.UTF8.GetString(Convert.FromBase64String(headerValueParts[1]));
+            int colonIndex = decoded.IndexOf(':');
+            if (colonIndex == -1)
+            {
+                // Return not authorized
+                session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid");
+                return false;
+            }
+
+            string username = decoded.Substring(0, colonIndex);
+            string password = decoded.Substring(colonIndex + 1);
+            bool authenticated = await AuthenticateUserFunc(username, password);
+            if (!authenticated)
+            {
+                session.WebSession.Response = createAuthentication407Response("Proxy Authentication Invalid");
+            }
+
+            return authenticated;
+        }
+
         /// <summary>
         ///     Create an authentication required response.
         /// </summary>
         /// <param name="description">Response description.</param>
         /// <returns></returns>
-        private Response createAuthentication407Response(string description)
+        private Response createAuthentication407Response(string description, string continuation = null)
         {
             var response = new Response
             {
@@ -90,10 +121,38 @@ namespace Titanium.Web.Proxy
                 StatusDescription = description
             };
 
-            response.Headers.AddHeader(KnownHeaders.ProxyAuthenticate, $"Basic realm=\"{ProxyRealm}\"");
+            if (!string.IsNullOrWhiteSpace(continuation))
+            {
+                return createContinuationResponse(response, continuation);
+            }
+
+            if (AuthenticateUserFunc != null)
+            {
+                response.Headers.AddHeader(KnownHeaders.ProxyAuthenticate, $"Basic realm=\"{ProxyRealm}\"");
+            }
+
+            if (AuthenticateSchemeFunc != null)
+            {
+                foreach (var scheme in SupportedAuthenticationSchemes)
+                {
+                    response.Headers.AddHeader(KnownHeaders.ProxyAuthenticate, scheme);
+                }
+            }
+
             response.Headers.AddHeader(KnownHeaders.ProxyConnection, KnownHeaders.ProxyConnectionClose);
 
             response.Headers.FixProxyHeaders();
+            return response;
+        }
+
+        private Response createContinuationResponse(Response response, string continuation)
+        {
+            response.Headers.AddHeader(KnownHeaders.ProxyAuthenticate, continuation);
+
+            response.Headers.AddHeader(KnownHeaders.ProxyConnection, KnownHeaders.ConnectionKeepAlive);
+            
+            response.Headers.FixProxyHeaders();
+
             return response;
         }
     }

--- a/Titanium.Web.Proxy/ProxyServer.cs
+++ b/Titanium.Web.Proxy/ProxyServer.cs
@@ -271,6 +271,18 @@ namespace Titanium.Web.Proxy
         public Func<string, string, Task<bool>> AuthenticateUserFunc { get; set; }
 
         /// <summary>
+        /// A pluggable callback to authenticate clients by scheme instead of requiring basic auth.
+        /// Parameters are current working session, schemeType, and token as provided by a calling client.
+        /// Should return success for successful authentication, continuation if the package requests, or failure.
+        /// </summary>
+        public Func<SessionEventArgsBase, string, string, Task<ProxyAuthenticationContext>> AuthenticateSchemeFunc { get; set; }
+
+        /// <summary>
+        /// A collection of scheme types, e.g. basic, NTLM, Kerberos, Negotiate, to return if authentication is required.
+        /// </summary>
+        public IEnumerable<string> SupportedAuthenticationSchemes { get; set; } = new string[0];
+
+        /// <summary>
         ///     Dispose the Proxy instance.
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
…for things like NTLM or Kerberos, instead of falling back to Basic.

This extends the original functionality by adding a delegate to check if an arbitrary scheme has been presented instead of just Basic. This includes the ability to use multi-trip handshakes like NTLM or Kerberos.

It's written such that it won't break any existing implementations using the original authentication path.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against develop branch 
