### PR TITLE
Fix PlatformNotSupportedException when running in docker on Linux

### DIFF
--- a/Titanium.Web.Proxy/Network/Certificate/BCCertificateMaker.cs
+++ b/Titanium.Web.Proxy/Network/Certificate/BCCertificateMaker.cs
@@ -16,6 +16,7 @@ using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities;
 using Org.BouncyCastle.X509;
+using Titanium.Web.Proxy.Helpers;
 using Titanium.Web.Proxy.Shared;
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
@@ -28,10 +29,6 @@ namespace Titanium.Web.Proxy.Network.Certificate
     {
         private const int certificateValidDays = 1825;
         private const int certificateGraceDays = 366;
-
-        // The FriendlyName value cannot be set on Unix.
-        // Set this flag to true when exception detected to avoid further exceptions
-        private static bool doNotSetFriendlyName;
 
         private readonly ExceptionHandler exceptionFunc;
 
@@ -146,19 +143,11 @@ namespace Titanium.Web.Proxy.Network.Certificate
             x509Certificate.PrivateKey = DotNetUtilities.ToRSA(rsaparams);
 #else
             var x509Certificate = withPrivateKey(certificate, rsaparams);
-            x509Certificate.FriendlyName = subjectName;
 #endif
 
-            if (!doNotSetFriendlyName)
+            if (RunTime.IsWindows)
             {
-                try
-                {
-                    x509Certificate.FriendlyName = ProxyConstants.CNRemoverRegex.Replace(subjectName, string.Empty);
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    doNotSetFriendlyName = true;
-                }
+                x509Certificate.FriendlyName = ProxyConstants.CNRemoverRegex.Replace(subjectName, string.Empty);
             }
 
             return x509Certificate;


### PR DESCRIPTION
Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ ] Branching - If this is not a hotfix, I am making this request against develop branch 


Tried to run Titanium-Web-Proxy in docker. Run into two problems:
1) Setting `FriendlyName` on `X509Certificate2` is not supported on Linux - and there was a bug here that it was being set always for .net standard (see pull request)
2) SNI is not supported for SslStream in .NET Core 2.0 on Linux. Will be added in .NET Core 2.1, as per this pull request: https://github.com/dotnet/corefx/pull/28278 - I'm willing to update wiki to let others know about this issue.

I've also decided to remove this `doNotSetFriendlyName` variable, as we know that `FriendlyName` is just not suppored on Linux and should do it only for Windows.