### PR TITLE
Fixing response status line parsing

### DIFF
--- a/Titanium.Web.Proxy/Http/Response.cs
+++ b/Titanium.Web.Proxy/Http/Response.cs
@@ -145,7 +145,7 @@ namespace Titanium.Web.Proxy.Http
             out string statusDescription)
         {
             var httpResult = httpStatus.Split(ProxyConstants.SpaceSplit, 3);
-            if (httpResult.Length != 3)
+            if (httpResult.Length <= 1)
             {
                 throw new Exception("Invalid HTTP status line: " + httpStatus);
             }
@@ -159,7 +159,7 @@ namespace Titanium.Web.Proxy.Http
             }
 
             statusCode = int.Parse(httpResult[1]);
-            statusDescription = httpResult[2];
+            statusDescription = httpResult.Length > 2 ? httpResult[2] : string.Empty;
         }
     }
 }


### PR DESCRIPTION
Fixing response status line parsing, so that status line is parsed correctly even if Reason-Phrase is missing. HTTP spec says the Reason-Phrase is optional.

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ ] Branching - If this is not a hotfix, I am making this request against master branch 
