### PR TITLE
Add brotli compression for windows

### DIFF
--- a/src/Titanium.Web.Proxy/Compression/CompressionFactory.cs
+++ b/src/Titanium.Web.Proxy/Compression/CompressionFactory.cs
@@ -20,11 +20,6 @@ namespace Titanium.Web.Proxy.Compression
                 case KnownHeaders.ContentEncodingDeflate:
                     return new DeflateStream(stream, CompressionMode.Compress, leaveOpen);
                 case KnownHeaders.ContentEncodingBrotli:
-                    if (!RunTime.IsWindows)
-                    {
-                        throw new PlatformNotSupportedException("BrotliSharpLib currently supports only Windows.");
-                    }
-
                     return new BrotliSharpLib.BrotliStream(stream, CompressionMode.Compress, leaveOpen);
                 default:
                     throw new Exception($"Unsupported compression mode: {type}");

--- a/src/Titanium.Web.Proxy/Compression/CompressionFactory.cs
+++ b/src/Titanium.Web.Proxy/Compression/CompressionFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using Titanium.Web.Proxy.Helpers;
 using Titanium.Web.Proxy.Http;
 
 namespace Titanium.Web.Proxy.Compression
@@ -18,6 +19,13 @@ namespace Titanium.Web.Proxy.Compression
                     return new GZipStream(stream, CompressionMode.Compress, leaveOpen);
                 case KnownHeaders.ContentEncodingDeflate:
                     return new DeflateStream(stream, CompressionMode.Compress, leaveOpen);
+                case KnownHeaders.ContentEncodingBrotli:
+                    if (!RunTime.IsWindows)
+                    {
+                        throw new PlatformNotSupportedException("BrotliSharpLib currently supports only Windows.");
+                    }
+
+                    return new BrotliSharpLib.BrotliStream(stream, CompressionMode.Compress, leaveOpen);
                 default:
                     throw new Exception($"Unsupported compression mode: {type}");
             }

--- a/src/Titanium.Web.Proxy/Compression/DecompressionFactory.cs
+++ b/src/Titanium.Web.Proxy/Compression/DecompressionFactory.cs
@@ -18,6 +18,8 @@ namespace Titanium.Web.Proxy.Compression
                     return new GZipStream(stream, CompressionMode.Decompress, leaveOpen);
                 case KnownHeaders.ContentEncodingDeflate:
                     return new DeflateStream(stream, CompressionMode.Decompress, leaveOpen);
+                case KnownHeaders.ContentEncodingBrotli:
+                    return new BrotliSharpLib.BrotliStream(stream, CompressionMode.Decompress, leaveOpen);
                 default:
                     throw new Exception($"Unsupported decompression mode: {type}");
             }

--- a/src/Titanium.Web.Proxy/Compression/DecompressionFactory.cs
+++ b/src/Titanium.Web.Proxy/Compression/DecompressionFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using Titanium.Web.Proxy.Helpers;
 using Titanium.Web.Proxy.Http;
 
 namespace Titanium.Web.Proxy.Compression
@@ -19,6 +20,11 @@ namespace Titanium.Web.Proxy.Compression
                 case KnownHeaders.ContentEncodingDeflate:
                     return new DeflateStream(stream, CompressionMode.Decompress, leaveOpen);
                 case KnownHeaders.ContentEncodingBrotli:
+                    if(!RunTime.IsWindows)
+                    {
+                        throw new PlatformNotSupportedException("BrotliSharpLib currently supports only Windows.");
+                    }
+
                     return new BrotliSharpLib.BrotliStream(stream, CompressionMode.Decompress, leaveOpen);
                 default:
                     throw new Exception($"Unsupported decompression mode: {type}");

--- a/src/Titanium.Web.Proxy/Compression/DecompressionFactory.cs
+++ b/src/Titanium.Web.Proxy/Compression/DecompressionFactory.cs
@@ -20,11 +20,6 @@ namespace Titanium.Web.Proxy.Compression
                 case KnownHeaders.ContentEncodingDeflate:
                     return new DeflateStream(stream, CompressionMode.Decompress, leaveOpen);
                 case KnownHeaders.ContentEncodingBrotli:
-                    if(!RunTime.IsWindows)
-                    {
-                        throw new PlatformNotSupportedException("BrotliSharpLib currently supports only Windows.");
-                    }
-
                     return new BrotliSharpLib.BrotliStream(stream, CompressionMode.Decompress, leaveOpen);
                 default:
                     throw new Exception($"Unsupported decompression mode: {type}");

--- a/src/Titanium.Web.Proxy/Http/KnownHeaders.cs
+++ b/src/Titanium.Web.Proxy/Http/KnownHeaders.cs
@@ -39,6 +39,7 @@
         public const string ContentEncoding = "content-encoding";
         public const string ContentEncodingDeflate = "deflate";
         public const string ContentEncodingGzip = "gzip";
+        public const string ContentEncodingBrotli = "br";
 
         public const string Location = "Location";
 

--- a/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BrotliSharpLib" Version="0.3.1" />
+    <PackageReference Include="CloudVeil.BrotliSharpLib" Version="0.3.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
     <PackageReference Include="StreamExtended" Version="1.0.179" />
   </ItemGroup>

--- a/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BrotliSharpLib" Version="0.3.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
     <PackageReference Include="StreamExtended" Version="1.0.179" />
   </ItemGroup>

--- a/src/Titanium.Web.Proxy/Titanium.Web.Proxy.nuspec
+++ b/src/Titanium.Web.Proxy/Titanium.Web.Proxy.nuspec
@@ -16,6 +16,7 @@
     <dependencies>
       <dependency id="StreamExtended" version="1.0.179" />
       <dependency id="Portable.BouncyCastle" version="1.8.2" />
+      <dependency id="BrotliSharpLib" version="0.3.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [ ] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. -- This supports only Windows. All other platforms currently throw a PlatformNotSupportedException for brotli.
- [ ] Branching - If this is not a hotfix, I am making this request against master branch 
