### PR TITLE
Update TransparentClientHandler.cs

### DIFF
--- a/src/Titanium.Web.Proxy/TransparentClientHandler.cs
+++ b/src/Titanium.Web.Proxy/TransparentClientHandler.cs
@@ -81,7 +81,7 @@ namespace Titanium.Web.Proxy
                             sslStream = new SslStream(clientStream);
 
                             string certName = HttpHelper.GetWildCardDomainName(httpsHostName);
-                            var certificate = await CertificateManager.CreateCertificateAsync(certName);
+                            var certificate = CertificateManager.RootCertificate ?? await CertificateManager.CreateCertificateAsync(certName);
 
                             // Successfully managed to authenticate the client using the fake certificate
                             await sslStream.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls, false);


### PR DESCRIPTION
#529 TransparentClientHandler doesn't use CertificateManager.RootCertificate for AuthenticateAsServerAsync #529

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against master branch 
