### PR TITLE
fix buffers returned to pool too early

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/HttpWriter.cs
+++ b/src/Titanium.Web.Proxy/Helpers/HttpWriter.cs
@@ -67,11 +67,15 @@ namespace Titanium.Web.Proxy.Helpers
                         idx += newLineChars;
                     }
 
-                    return stream.WriteAsync(buffer, 0, idx, cancellationToken);
+                    return stream.WriteAsync(buffer, 0, idx, cancellationToken).ContinueWith((antecedent) =>
+                    {
+                        bufferPool.ReturnBuffer(buffer);
+                    });
                 }
-                finally
+                catch(Exception ex)
                 {
                     bufferPool.ReturnBuffer(buffer);
+                    throw ex;
                 }
             }
             else


### PR DESCRIPTION
buffers were returned to the pool before the write operation finished, which lead to corrupted buffers

Doneness:
- [ ] Build is okay - I made sure that this change is building successfully.
- [ ] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ ] Branching - If this is not a hotfix, I am making this request against master branch 
