### PR TITLE
Add ThreadPool tuning for better performances when heavy load

### DIFF
--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -57,11 +57,10 @@ namespace Titanium.Web.Proxy
         /// </summary>
         private WinHttpWebProxyFinder systemProxyResolver;
 
-
         /// <summary>
-        ///     
+        ///     lock for Thread Pool tuning
         /// </summary>
-        private object lockThreadPoolSettings = new object();
+        private object lockThreadPoolTuning = new object();
 
         /// <inheritdoc />
         /// <summary>
@@ -755,7 +754,7 @@ namespace Titanium.Web.Proxy
         {
             if (EnableThreadPoolOptimizing)
             {
-                lock (lockThreadPoolSettings)
+                lock (lockThreadPoolTuning)
                 {
                     int iWorkerThreads, iCompletionPortThreads;
                     ThreadPool.GetMinThreads(out iWorkerThreads, out iCompletionPortThreads);

--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -57,6 +57,12 @@ namespace Titanium.Web.Proxy
         /// </summary>
         private WinHttpWebProxyFinder systemProxyResolver;
 
+
+        /// <summary>
+        ///     
+        /// </summary>
+        private object lockThreadPoolSettings = new object();
+
         /// <inheritdoc />
         /// <summary>
         ///     Initializes a new instance of ProxyServer class with provided parameters.
@@ -172,6 +178,12 @@ namespace Titanium.Web.Proxy
         ///     Defaults to true.
         /// </summary>
         public bool EnableTcpServerConnectionPrefetch { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a Boolean value that specifies whether ThreadPool grows new connections and decrease when connections close
+        /// Defaults to true.
+        /// </summary>
+        public bool EnableThreadPoolOptimizing { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a Boolean value that specifies whether server and client stream Sockets are using the Nagle algorithm.
@@ -721,11 +733,36 @@ namespace Titanium.Web.Proxy
 
             if (tcpClient != null)
             {
-                Task.Run(async () => { await handleClient(tcpClient, endPoint); });
+                SetThreadPoolMinThread(1); // increase the ThreadPool 
+
+                Task.Run(async () =>
+                {
+                    await handleClient(tcpClient, endPoint);
+
+                    SetThreadPoolMinThread(-1); //decrease the Threadpool
+                });
             }
 
             // Get the listener that handles the client request.
             endPoint.Listener.BeginAcceptTcpClient(onAcceptConnection, endPoint);
+        }
+
+        /// <summary>
+        /// Change the ThreadPool.WorkerThread minThread 
+        /// </summary>
+        /// <param name="piNbWorkerThreadsToAdd">Number of threads to add</param>
+        void SetThreadPoolMinThread(int piNbWorkerThreadsToAdd)
+        {
+            if (EnableThreadPoolOptimizing)
+            {
+                lock (lockThreadPoolSettings)
+                {
+                    int iWorkerThreads, iCompletionPortThreads;
+                    ThreadPool.GetMinThreads(out iWorkerThreads, out iCompletionPortThreads);
+                    iWorkerThreads = Math.Max(iWorkerThreads + piNbWorkerThreadsToAdd, Environment.ProcessorCount);
+                    ThreadPool.SetMinThreads(iWorkerThreads, iCompletionPortThreads);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Doneness:
- [X ] Build is okay - I made sure that this change is building successfully.
- [ X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ X] Branching - If this is not a hotfix, I am making this request against the master branch 

Tasks use ThreadPool. 
By default there is only few threads available (approx 20), and if you start the proxy and open a heavy website with hundred requests (like www.lemonde.fr) it could hang for approx 20sec (because of the task scheduler), and then continue. 
On possibility is to rewrite Titanium without async/await... 
And the other - and probably the best - is to tune ThreadPool.MinThreadWorker based on the connections opening/close, it works really better with that (have a try with a lot of new tab with heavy site).
Some developers could not like this feature so I add the feature as an option (ProxyServer.EnableThreadPoolOptimizing)