### PR TITLE
Don't change the Server Socket SendBufferSize or ReceiveBufferSize

### DIFF
--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -274,8 +274,6 @@ namespace Titanium.Web.Proxy.Network.Tcp
 					NoDelay = proxyServer.NoDelay,
                     ReceiveTimeout = proxyServer.ConnectionTimeOutSeconds * 1000,
                     SendTimeout = proxyServer.ConnectionTimeOutSeconds * 1000,
-                    SendBufferSize = proxyServer.BufferSize,
-                    ReceiveBufferSize = proxyServer.BufferSize,
                     LingerState = new LingerOption(true, proxyServer.TcpTimeWaitSeconds)
                 };
 


### PR DESCRIPTION
Doneness:
- [ X] Build is okay - I made sure that this change is building successfully.
- [ X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ X] Branching - If this is not a hotfix, I am making this request against the master branch 

On server connection - when you download/upload on the Internet - it's really faster to send/receive data with the default 64k buffer. If you try to change the SendTimeout/ReceiveTimeout socket values, it will have worst performances.