### PR TITLE
Remove ThreadPool auto optimizations, add a manual ThreadPoolWorkerThread

### DIFF
--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -274,8 +274,6 @@ namespace Titanium.Web.Proxy.Network.Tcp
 					NoDelay = proxyServer.NoDelay,
                     ReceiveTimeout = proxyServer.ConnectionTimeOutSeconds * 1000,
                     SendTimeout = proxyServer.ConnectionTimeOutSeconds * 1000,
-                    SendBufferSize = proxyServer.BufferSize,
-                    ReceiveBufferSize = proxyServer.BufferSize,
                     LingerState = new LingerOption(true, proxyServer.TcpTimeWaitSeconds)
                 };
 


### PR DESCRIPTION
Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against the master branch 

Remove the ThreadPool optimization stuff, useless now with the bug fix for Stream-Extended (https://github.com/justcoding121/Stream-Extended/pull/44).
I add a new setting param "ThreadPoolWorkerThread" for tuning the ThreadPool once instead (usefull for servers)

Example:

     proxyServer.ThreadPoolWorkerThread = Environment.ProcessorCount * 6;
