### PR TITLE
allow to modify HTTP/2 header

### DIFF
--- a/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
@@ -159,6 +159,9 @@ namespace Titanium.Web.Proxy.Examples.Wpf
             //{
             //}
 
+            //if (!e.HttpClient.Request.RequestUri.ToString().Contains("/mail/u/"))
+            //    return;
+
             if (e.HttpClient.Request.HasBody)
             {
                 e.HttpClient.Request.KeepBody = true;
@@ -177,7 +180,10 @@ namespace Titanium.Web.Proxy.Examples.Wpf
                 }
             });
 
-            e.HttpClient.Response.Headers.AddHeader("X-Titanium-Header", "HTTP/2 works");
+            //e.SetResponseBody(Encoding.ASCII.GetBytes("TITANIUMMMM!!!!"));
+            //if (!e.HttpClient.Request.RequestUri.ToString().Contains("/mail/u/"))
+            //    return;
+            //e.HttpClient.Response.Headers.AddHeader("X-Titanium-Header", "HTTP/2 works");
 
             //if (e.HttpClient.ConnectRequest?.TunnelType == TunnelType.Http2)
             //{

--- a/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
@@ -177,6 +177,8 @@ namespace Titanium.Web.Proxy.Examples.Wpf
                 }
             });
 
+            e.HttpClient.Response.Headers.AddHeader("X-Titanium-Header", "HTTP/2 works");
+
             //if (e.HttpClient.ConnectRequest?.TunnelType == TunnelType.Http2)
             //{
             //}

--- a/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
@@ -152,6 +152,11 @@ namespace Titanium.Web.Proxy.Examples.Wpf
 
         private async Task ProxyServer_BeforeRequest(object sender, SessionEventArgs e)
         {
+            if (e.HttpClient.ConnectRequest?.TunnelType != TunnelType.Http2)
+            {
+                return;
+            }
+
             SessionListItem item = null;
             await Dispatcher.InvokeAsync(() => { item = addSession(e); });
 
@@ -171,6 +176,11 @@ namespace Titanium.Web.Proxy.Examples.Wpf
 
         private async Task ProxyServer_BeforeResponse(object sender, SessionEventArgs e)
         {
+            if (e.HttpClient.ConnectRequest?.TunnelType != TunnelType.Http2)
+            {
+                return;
+            }
+
             SessionListItem item = null;
             await Dispatcher.InvokeAsync(() =>
             {
@@ -180,14 +190,9 @@ namespace Titanium.Web.Proxy.Examples.Wpf
                 }
             });
 
-            //e.SetResponseBody(Encoding.ASCII.GetBytes("TITANIUMMMM!!!!"));
-            //if (!e.HttpClient.Request.RequestUri.ToString().Contains("/mail/u/"))
-            //    return;
             //e.HttpClient.Response.Headers.AddHeader("X-Titanium-Header", "HTTP/2 works");
 
-            //if (e.HttpClient.ConnectRequest?.TunnelType == TunnelType.Http2)
-            //{
-            //}
+            //e.SetResponseBody(Encoding.ASCII.GetBytes("TITANIUMMMM!!!!"));
 
             if (item != null)
             {

--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
@@ -91,6 +91,9 @@ namespace Titanium.Web.Proxy.EventArguments
             {
                 if (request.HttpVersion == HttpHeader.Version20)
                 {
+                    // do not send to the remote endpoint
+                    request.Http2IgnoreBodyFrames = true;
+
                     request.Http2BodyData = new MemoryStream();
 
                     var tcs = new TaskCompletionSource<bool>();
@@ -100,6 +103,10 @@ namespace Titanium.Web.Proxy.EventArguments
                     request.ReadHttp2BeforeHandlerTaskCompletionSource.SetResult(true);
 
                     await tcs.Task;
+
+                    // Now set the flag to true
+                    // So that next time we can deliver body from cache
+                    request.IsBodyRead = true;
                 }
                 else
                 {
@@ -157,6 +164,9 @@ namespace Titanium.Web.Proxy.EventArguments
             {
                 if (response.HttpVersion == HttpHeader.Version20)
                 {
+                    // do not send to the remote endpoint
+                    response.Http2IgnoreBodyFrames = true;
+
                     response.Http2BodyData = new MemoryStream();
 
                     var tcs = new TaskCompletionSource<bool>();
@@ -166,6 +176,10 @@ namespace Titanium.Web.Proxy.EventArguments
                     response.ReadHttp2BeforeHandlerTaskCompletionSource.SetResult(true);
 
                     await tcs.Task;
+
+                    // Now set the flag to true
+                    // So that next time we can deliver body from cache
+                    response.IsBodyRead = true;
                 }
                 else
                 {

--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
@@ -29,6 +29,11 @@ namespace Titanium.Web.Proxy.EventArguments
         private bool reRequest;
 
         /// <summary>
+        ///     Is this session a HTTP/2 promise?
+        /// </summary>
+        public bool IsPromise { get; internal set; }
+
+        /// <summary>
         /// Constructor to initialize the proxy
         /// </summary>
         internal SessionEventArgs(ProxyServer server, ProxyEndPoint endPoint,

--- a/src/Titanium.Web.Proxy/Http/RequestResponseBase.cs
+++ b/src/Titanium.Web.Proxy/Http/RequestResponseBase.cs
@@ -56,6 +56,15 @@ namespace Titanium.Web.Proxy.Http
 
         internal MemoryStream Http2BodyData;
 
+        internal bool Http2IgnoreBodyFrames;
+
+        internal Task Http2BeforeHandlerTask;
+
+        /// <summary>
+        ///     Priority used only in HTTP/2
+        /// </summary>
+        internal long? Priority;
+
         /// <summary>
         ///     Keeps the body data after the session is finished.
         /// </summary>
@@ -200,6 +209,8 @@ namespace Titanium.Web.Proxy.Http
         ///     Also if user set this as a custom response then this should be true.
         /// </summary>
         internal bool Locked { get; set; }
+
+        internal bool BodyAvailable => BodyInternal != null;
 
         internal abstract void EnsureBodyAvailable(bool throwWhenNotReadYet = true);
 

--- a/src/Titanium.Web.Proxy/Http2/Hpack/StaticTable.cs
+++ b/src/Titanium.Web.Proxy/Http2/Hpack/StaticTable.cs
@@ -154,7 +154,7 @@ namespace Titanium.Web.Proxy.Http2.Hpack
             new HttpHeader("WWW-Authenticate", string.Empty)
         };
 
-        private static readonly Dictionary<string, int> staticIndexByName = CreateMap();
+        private static readonly Dictionary<string, int> staticIndexByName = createMap();
 
         /// <summary>
         /// The number of header fields in the static table.
@@ -180,12 +180,12 @@ namespace Titanium.Web.Proxy.Http2.Hpack
         /// <param name="name">Name.</param>
         public static int GetIndex(string name)
         {
-            if (!staticIndexByName.ContainsKey(name))
+            if (!staticIndexByName.TryGetValue(name, out int index))
             {
                 return -1;
             }
 
-            return staticIndexByName[name];
+            return index;
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace Titanium.Web.Proxy.Http2.Hpack
             while (index <= Length)
             {
                 var entry = Get(index);
-                if (!HpackUtil.Equals(name, entry.Name))
+                if (!name.Equals(entry.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     break;
                 }
@@ -227,7 +227,7 @@ namespace Titanium.Web.Proxy.Http2.Hpack
         /// create a map of header name to index value to allow quick lookup
         /// </summary>
         /// <returns>The map.</returns>
-        private static Dictionary<string, int> CreateMap()
+        private static Dictionary<string, int> createMap()
         {
             int length = staticTable.Count;
             var ret = new Dictionary<string, int>(length);
@@ -237,7 +237,7 @@ namespace Titanium.Web.Proxy.Http2.Hpack
             for (int index = length; index > 0; index--)
             {
                 var entry = Get(index);
-                string name = entry.Name;
+                string name = entry.Name.ToLower();
                 ret[name] = index;
             }
 

--- a/src/Titanium.Web.Proxy/Http2/Http2FrameFlag.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2FrameFlag.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Titanium.Web.Proxy.Http2
+{
+    [Flags]
+    internal enum Http2FrameFlag : byte
+    {
+        Ack = 0x01,
+        EndStream = 0x01,
+        EndHeaders = 0x04,
+        Padded = 0x08,
+        Priority = 0x20,
+    }
+}

--- a/src/Titanium.Web.Proxy/Http2/Http2FrameHeader.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2FrameHeader.cs
@@ -1,0 +1,27 @@
+﻿namespace Titanium.Web.Proxy.Http2
+{
+    internal class Http2FrameHeader
+    {
+        public int Length;
+
+        public Http2FrameType Type;
+
+        public Http2FrameFlag Flags;
+
+        public int StreamId;
+
+        public byte[] Buffer;
+
+        public byte[] CopyToBuffer()
+        {
+            int length = Length;
+            var buf = Buffer;
+            buf[0] = (byte)((length >> 16) & 0xff);
+            buf[1] = (byte)((length >> 8) & 0xff);
+            buf[2] = (byte)(length & 0xff);
+            buf[3] = (byte)Type;
+            buf[4] = (byte)Flags;
+            return buf;
+        }
+    }
+}

--- a/src/Titanium.Web.Proxy/Http2/Http2FrameHeader.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2FrameHeader.cs
@@ -15,12 +15,17 @@
         public byte[] CopyToBuffer()
         {
             int length = Length;
-            var buf = Buffer;
+            var buf = /*new byte[9];*/Buffer;
             buf[0] = (byte)((length >> 16) & 0xff);
             buf[1] = (byte)((length >> 8) & 0xff);
             buf[2] = (byte)(length & 0xff);
             buf[3] = (byte)Type;
             buf[4] = (byte)Flags;
+            int streamId = StreamId;
+            //buf[5] = (byte)((streamId >> 24) & 0xff);
+            //buf[6] = (byte)((streamId >> 16) & 0xff);
+            //buf[7] = (byte)((streamId >> 8) & 0xff);
+            //buf[8] = (byte)(streamId & 0xff);
             return buf;
         }
     }

--- a/src/Titanium.Web.Proxy/Http2/Http2FrameType.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2FrameType.cs
@@ -1,0 +1,16 @@
+﻿namespace Titanium.Web.Proxy.Http2
+{
+    internal enum Http2FrameType : byte
+    {
+        Data = 0x00,
+        Headers = 0x01,
+        Priority = 0x02,
+        RstStream = 0x03,
+        Settings = 0x04,
+        PushPromise = 0x05,
+        Ping = 0x06,
+        GoAway = 0x07,
+        WindowUpdate = 0x08,
+        Continuation = 0x09,
+    }
+}

--- a/src/Titanium.Web.Proxy/Models/HttpHeader.cs
+++ b/src/Titanium.Web.Proxy/Models/HttpHeader.cs
@@ -35,9 +35,16 @@ namespace Titanium.Web.Proxy.Models
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new Exception("Name cannot be null");
+                throw new Exception("Name cannot be null or empty");
             }
 
+            Name = name.Trim();
+            Value = value.Trim();
+        }
+
+        protected HttpHeader(string name, string value, bool headerEntry)
+        {
+            // special header entry created in inherited class with empty name
             Name = name.Trim();
             Value = value.Trim();
         }

--- a/src/Titanium.Web.Proxy/ResponseHandler.cs
+++ b/src/Titanium.Web.Proxy/ResponseHandler.cs
@@ -125,7 +125,6 @@ namespace Titanium.Web.Proxy
             }
 
             args.TimeLine["Response Sent"] = DateTime.Now;
-
         }
 
         /// <summary>


### PR DESCRIPTION
Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [ ] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against the master branch 

known issues: 
- some http/2 validation is not enforced
- generated header is always 1 frame (can be bigger than a valid frame size), however I never saw any splitted header, yet
- copyHttp2FrameAsync method looks ugly, especially the encoding part, long