### PR TITLE
do not throw exception in fillbuffer (only when it called on an alrea…

### DIFF
--- a/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Wpf/MainWindow.xaml.cs
@@ -159,6 +159,11 @@ namespace Titanium.Web.Proxy.Examples.Wpf
             {
                 e.HttpClient.Request.KeepBody = true;
                 await e.GetRequestBody();
+
+                if (item == SelectedSession)
+                {
+                    await Dispatcher.InvokeAsync(selectedSessionChanged);
+                }
             }
         }
 
@@ -185,6 +190,10 @@ namespace Titanium.Web.Proxy.Examples.Wpf
                     await e.GetResponseBody();
 
                     await Dispatcher.InvokeAsync(() => { item.Update(); });
+                    if (item == SelectedSession)
+                    {
+                        await Dispatcher.InvokeAsync(selectedSessionChanged);
+                    }
                 }
             }
         }


### PR DESCRIPTION
…dy closed stream)

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against the master branch 
