### PR TITLE
Enable socket reuse based on framework

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/RunTime.cs
+++ b/src/Titanium.Web.Proxy/Helpers/RunTime.cs
@@ -74,10 +74,10 @@ namespace Titanium.Web.Proxy.Helpers
                     return false; // play it safe if we can not figure out what the framework is
 
                 // make sure we are on .NETCoreApp
-                if (ver.Contains(".NETCoreApp", StringComparison.InvariantCultureIgnoreCase))
+                ver = ver.ToLower(); // make everything lowercase to simplify comparison
+                if (ver.Contains(".netcoreapp", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    var versionString = ver.Replace(".NETCoreApp,Version=v", "",
-                        StringComparison.InvariantCultureIgnoreCase);
+                    var versionString = ver.Replace(".netcoreapp,version=v", "");
                     var versionArr = versionString.Split('.');
                     var majorVersion = Convert.ToInt32(versionArr[0]);
 

--- a/src/Titanium.Web.Proxy/Helpers/RunTime.cs
+++ b/src/Titanium.Web.Proxy/Helpers/RunTime.cs
@@ -75,7 +75,7 @@ namespace Titanium.Web.Proxy.Helpers
 
                 // make sure we are on .NETCoreApp
                 ver = ver.ToLower(); // make everything lowercase to simplify comparison
-                if (ver.Contains(".netcoreapp", StringComparison.InvariantCultureIgnoreCase))
+                if (ver.Contains(".netcoreapp"))
                 {
                     var versionString = ver.Replace(".netcoreapp,version=v", "");
                     var versionArr = versionString.Split('.');

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -315,8 +315,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                         tcpClient.SendTimeout = proxyServer.ConnectionTimeOutSeconds * 1000;
                         tcpClient.LingerState = new LingerOption(true, proxyServer.TcpTimeWaitSeconds);
 
-                        // linux has a bug with socket reuse in .net core.
-                        if (proxyServer.ReuseSocket && RunTime.IsWindows)
+                        if (proxyServer.ReuseSocket && RunTime.IsSocketReuseAvailable)
                         {
                             tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                         }

--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -654,8 +654,7 @@ namespace Titanium.Web.Proxy
         {
             endPoint.Listener = new TcpListener(endPoint.IpAddress, endPoint.Port);
 
-            // linux/macOS has a bug with socket reuse in .net core.
-            if (ReuseSocket && RunTime.IsWindows)
+            if (ReuseSocket && RunTime.IsSocketReuseAvailable)
             {
                 endPoint.Listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             }


### PR DESCRIPTION
Adds RunTime.IsSocketReuseAvailable and adds the ability to use socket reuse outside of windows depending on the framework version. (Bug that was causing issues has been fixed in core 3.0+).

Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ ] Branching - If this is not a hotfix, I am making this request against the master branch 
