### PR TITLE
Enable socket reuse based on framework version via RunTime.IsSocketReuseAvailable

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/RunTime.cs
+++ b/src/Titanium.Web.Proxy/Helpers/RunTime.cs
@@ -41,6 +41,62 @@ namespace Titanium.Web.Proxy.Helpers
         public static bool IsUwpOnWindows => IsWindows && UwpHelper.IsRunningAsUwp();
 
         public static bool IsMac => isRunningOnMac;
+        
+        /// <summary>
+        /// Is socket reuse available to use?
+        /// </summary>
+        public static bool IsSocketReuseAvailable => isSocketReuseAvailable();
+
+        private static bool? _isSocketReuseAvailable;
+
+        private static bool isSocketReuseAvailable()
+        {
+            // use the cached value if we have one
+            if (_isSocketReuseAvailable != null)
+                return _isSocketReuseAvailable.Value;
+
+            try
+            {
+                if (IsWindows)
+                {
+                    // since we are on windows just return true
+                    // store the result in our static object so we don't have to be bothered going through all this more than once
+                    _isSocketReuseAvailable = true;
+                    return true;
+                }
+
+                // get the currently running framework name and version (EX: .NETFramework,Version=v4.5.1) (Ex: .NETCoreApp,Version=v2.0)
+                string ver = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+
+                if (ver == null)
+                    return false; // play it safe if we can not figure out what the framework is
+
+                // make sure we are on .NETCoreApp
+                ver = ver.ToLower(); // make everything lowercase to simplify comparison
+                if (ver.Contains(".netcoreapp"))
+                {
+                    var versionString = ver.Replace(".netcoreapp,version=v", "");
+                    var versionArr = versionString.Split('.');
+                    var majorVersion = Convert.ToInt32(versionArr[0]);
+
+                    var result = majorVersion >= 3; // version 3 and up supports socket reuse
+
+                    // store the result in our static object so we don't have to be bothered going through all this more than once
+                    _isSocketReuseAvailable = result;
+                    return result;
+                }
+
+                // store the result in our static object so we don't have to be bothered going through all this more than once
+                _isSocketReuseAvailable = false;
+                return false;
+            }
+            catch
+            {
+                // store the result in our static object so we don't have to be bothered going through all this more than once
+                _isSocketReuseAvailable = false;
+                return false;
+            }
+        }
 
         // https://github.com/qmatteoq/DesktopBridgeHelpers/blob/master/DesktopBridge.Helpers/Helpers.cs
         private class UwpHelper

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -315,8 +315,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                         tcpClient.SendTimeout = proxyServer.ConnectionTimeOutSeconds * 1000;
                         tcpClient.LingerState = new LingerOption(true, proxyServer.TcpTimeWaitSeconds);
 
-                        // linux has a bug with socket reuse in .net core.
-                        if (proxyServer.ReuseSocket && RunTime.IsWindows)
+                        if (proxyServer.ReuseSocket && RunTime.IsSocketReuseAvailable)
                         {
                             tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                         }

--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -654,8 +654,7 @@ namespace Titanium.Web.Proxy
         {
             endPoint.Listener = new TcpListener(endPoint.IpAddress, endPoint.Port);
 
-            // linux/macOS has a bug with socket reuse in .net core.
-            if (ReuseSocket && RunTime.IsWindows)
+            if (ReuseSocket && RunTime.IsSocketReuseAvailable)
             {
                 endPoint.Listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             }


### PR DESCRIPTION
Doneness:
- [X] Build is okay - I made sure that this change is building successfully.
- [X] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [X] Branching - If this is not a hotfix, I am making this request against the master branch 
