### PR TITLE
fixed "Windows Authentication is not supported" error on non-Windows systems

### DIFF
--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
@@ -84,7 +84,7 @@ namespace Titanium.Web.Proxy.EventArguments
             get => enableWinAuth;
             set
             {
-                if (!isWindowsAuthenticationSupported)
+                if (value && !isWindowsAuthenticationSupported)
                     throw new Exception("Windows Authentication is not supported");
 
                 enableWinAuth = value;


### PR DESCRIPTION

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the master branch 
