### PR TITLE
ExternalProxy interface

### DIFF
--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
@@ -106,7 +106,7 @@ namespace Titanium.Web.Proxy.EventArguments
         /// <summary>
         ///     Are we using a custom upstream HTTP(S) proxy?
         /// </summary>
-        public ExternalProxy? CustomUpStreamProxyUsed { get; internal set; }
+        public IExternalProxy? CustomUpStreamProxyUsed { get; internal set; }
 
         /// <summary>
         ///     Local endpoint via which we make the request.

--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
@@ -106,7 +106,7 @@ namespace Titanium.Web.Proxy.EventArguments
         /// <summary>
         ///     Are we using a custom upstream HTTP(S) proxy?
         /// </summary>
-        public IExternalProxy? CustomUpStreamProxyUsed { get; internal set; }
+        public ExternalProxy? CustomUpStreamProxyUsed { get; internal set; }
 
         /// <summary>
         ///     Local endpoint via which we make the request.

--- a/src/Titanium.Web.Proxy/Helpers/WinHttp/WinHttpWebProxyFinder.cs
+++ b/src/Titanium.Web.Proxy/Helpers/WinHttp/WinHttpWebProxyFinder.cs
@@ -95,7 +95,7 @@ namespace Titanium.Web.Proxy.Helpers.WinHttp
             return true;
         }
 
-        public ExternalProxy? GetProxy(Uri destination)
+        public IExternalProxy? GetProxy(Uri destination)
         {
             if (GetAutoProxies(destination, out var proxies))
             {

--- a/src/Titanium.Web.Proxy/Helpers/WinHttp/WinHttpWebProxyFinder.cs
+++ b/src/Titanium.Web.Proxy/Helpers/WinHttp/WinHttpWebProxyFinder.cs
@@ -95,7 +95,7 @@ namespace Titanium.Web.Proxy.Helpers.WinHttp
             return true;
         }
 
-        public IExternalProxy? GetProxy(Uri destination)
+        public ExternalProxy? GetProxy(Uri destination)
         {
             if (GetAutoProxies(destination, out var proxies))
             {

--- a/src/Titanium.Web.Proxy/Models/ExternalProxy.cs
+++ b/src/Titanium.Web.Proxy/Models/ExternalProxy.cs
@@ -6,7 +6,7 @@ namespace Titanium.Web.Proxy.Models
     /// <summary>
     ///     An upstream proxy this proxy uses if any.
     /// </summary>
-    public class ExternalProxy
+    public class ExternalProxy : IExternalProxy
     {
         private static readonly Lazy<NetworkCredential> defaultCredentials =
             new Lazy<NetworkCredential>(() => CredentialCache.DefaultNetworkCredentials);

--- a/src/Titanium.Web.Proxy/Models/ExternalProxy.cs
+++ b/src/Titanium.Web.Proxy/Models/ExternalProxy.cs
@@ -6,7 +6,7 @@ namespace Titanium.Web.Proxy.Models
     /// <summary>
     ///     An upstream proxy this proxy uses if any.
     /// </summary>
-    public class ExternalProxy : IExternalProxy
+    public class ExternalProxy
     {
         private static readonly Lazy<NetworkCredential> defaultCredentials =
             new Lazy<NetworkCredential>(() => CredentialCache.DefaultNetworkCredentials);

--- a/src/Titanium.Web.Proxy/Models/IExternalProxy.cs
+++ b/src/Titanium.Web.Proxy/Models/IExternalProxy.cs
@@ -5,17 +5,17 @@
         /// <summary>
         ///     Use default windows credentials?
         /// </summary>
-        public bool UseDefaultCredentials { get; set; }
+        bool UseDefaultCredentials { get; set; }
 
         /// <summary>
         ///     Bypass this proxy for connections to localhost?
         /// </summary>
-        public bool BypassLocalhost { get; set; }
+        bool BypassLocalhost { get; set; }
 
         /// <summary>
         ///     Username.
         /// </summary>
-        public string? UserName { get; set; }
+        string? UserName { get; set; }
 
         /// <summary>
         ///     Password.

--- a/src/Titanium.Web.Proxy/Models/IExternalProxy.cs
+++ b/src/Titanium.Web.Proxy/Models/IExternalProxy.cs
@@ -1,0 +1,37 @@
+﻿namespace Titanium.Web.Proxy.Models
+{
+    public interface IExternalProxy
+    {
+        /// <summary>
+        ///     Use default windows credentials?
+        /// </summary>
+        public bool UseDefaultCredentials { get; set; }
+
+        /// <summary>
+        ///     Bypass this proxy for connections to localhost?
+        /// </summary>
+        public bool BypassLocalhost { get; set; }
+
+        /// <summary>
+        ///     Username.
+        /// </summary>
+        public string? UserName { get; set; }
+
+        /// <summary>
+        ///     Password.
+        /// </summary>
+        string? Password { get; set; }
+
+        /// <summary>
+        ///     Host name.
+        /// </summary>
+        string HostName { get; set; }
+
+        /// <summary>
+        ///     Port.
+        /// </summary>
+        int Port { get; set; }
+
+        string ToString();
+    }
+}

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -49,7 +49,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
         internal string GetConnectionCacheKey(string remoteHostName, int remotePort,
             bool isHttps, List<SslApplicationProtocol>? applicationProtocols,
-            IPEndPoint? upStreamEndPoint, ExternalProxy? externalProxy)
+            IPEndPoint? upStreamEndPoint, IExternalProxy? externalProxy)
         {
             // http version is ignored since its an application level decision b/w HTTP 1.0/1.1
             // also when doing connect request MS Edge browser sends http 1.0 but uses 1.1 after server sends 1.1 its response.
@@ -115,7 +115,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 applicationProtocols = new List<SslApplicationProtocol> { applicationProtocol };
             }
 
-            ExternalProxy? customUpStreamProxy = null;
+            IExternalProxy? customUpStreamProxy = null;
 
             bool isHttps = session.IsHttps;
             if (server.GetCustomUpStreamProxyFunc != null)
@@ -170,7 +170,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         internal async Task<TcpServerConnection> GetServerConnection(ProxyServer server, SessionEventArgsBase session, bool isConnect,
             List<SslApplicationProtocol>? applicationProtocols, bool noCache, CancellationToken cancellationToken)
         {
-            ExternalProxy? customUpStreamProxy = null;
+            IExternalProxy? customUpStreamProxy = null;
 
             bool isHttps = session.IsHttps;
             if (server.GetCustomUpStreamProxyFunc != null)
@@ -208,7 +208,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         /// <returns></returns>
         internal async Task<TcpServerConnection> GetServerConnection(string remoteHostName, int remotePort,
             Version httpVersion, bool isHttps, List<SslApplicationProtocol>? applicationProtocols, bool isConnect,
-            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, ExternalProxy? externalProxy,
+            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, IExternalProxy? externalProxy,
             bool noCache, CancellationToken cancellationToken)
         {
             var sslProtocol = session?.ProxyClient.Connection.SslProtocol ?? SslProtocols.None;
@@ -262,7 +262,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         /// <returns></returns>
         private async Task<TcpServerConnection> createServerConnection(string remoteHostName, int remotePort,
             Version httpVersion, bool isHttps, SslProtocols sslProtocol, List<SslApplicationProtocol>? applicationProtocols, bool isConnect,
-            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, ExternalProxy? externalProxy, string cacheKey,
+            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, IExternalProxy? externalProxy, string cacheKey,
             CancellationToken cancellationToken)
         {
             // deny connection to proxy end points to avoid infinite connection loop.
@@ -304,7 +304,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
             bool retry = true;
             var enabledSslProtocols = sslProtocol;
 
-            retry:
+retry:
             try
             {
                 string hostname = useUpstreamProxy ? externalProxy!.HostName : remoteHostName;

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -49,7 +49,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
         internal string GetConnectionCacheKey(string remoteHostName, int remotePort,
             bool isHttps, List<SslApplicationProtocol>? applicationProtocols,
-            IPEndPoint? upStreamEndPoint, IExternalProxy? externalProxy)
+            IPEndPoint? upStreamEndPoint, ExternalProxy? externalProxy)
         {
             // http version is ignored since its an application level decision b/w HTTP 1.0/1.1
             // also when doing connect request MS Edge browser sends http 1.0 but uses 1.1 after server sends 1.1 its response.
@@ -115,7 +115,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
                 applicationProtocols = new List<SslApplicationProtocol> { applicationProtocol };
             }
 
-            IExternalProxy? customUpStreamProxy = null;
+            ExternalProxy? customUpStreamProxy = null;
 
             bool isHttps = session.IsHttps;
             if (server.GetCustomUpStreamProxyFunc != null)
@@ -170,7 +170,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         internal async Task<TcpServerConnection> GetServerConnection(ProxyServer server, SessionEventArgsBase session, bool isConnect,
             List<SslApplicationProtocol>? applicationProtocols, bool noCache, CancellationToken cancellationToken)
         {
-            IExternalProxy? customUpStreamProxy = null;
+            ExternalProxy? customUpStreamProxy = null;
 
             bool isHttps = session.IsHttps;
             if (server.GetCustomUpStreamProxyFunc != null)
@@ -208,7 +208,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         /// <returns></returns>
         internal async Task<TcpServerConnection> GetServerConnection(string remoteHostName, int remotePort,
             Version httpVersion, bool isHttps, List<SslApplicationProtocol>? applicationProtocols, bool isConnect,
-            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, IExternalProxy? externalProxy,
+            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, ExternalProxy? externalProxy,
             bool noCache, CancellationToken cancellationToken)
         {
             var sslProtocol = session?.ProxyClient.Connection.SslProtocol ?? SslProtocols.None;
@@ -262,7 +262,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
         /// <returns></returns>
         private async Task<TcpServerConnection> createServerConnection(string remoteHostName, int remotePort,
             Version httpVersion, bool isHttps, SslProtocols sslProtocol, List<SslApplicationProtocol>? applicationProtocols, bool isConnect,
-            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, IExternalProxy? externalProxy, string cacheKey,
+            ProxyServer proxyServer, SessionEventArgsBase? session, IPEndPoint? upStreamEndPoint, ExternalProxy? externalProxy, string cacheKey,
             CancellationToken cancellationToken)
         {
             // deny connection to proxy end points to avoid infinite connection loop.
@@ -304,7 +304,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
             bool retry = true;
             var enabledSslProtocols = sslProtocol;
 
-retry:
+            retry:
             try
             {
                 string hostname = useUpstreamProxy ? externalProxy!.HostName : remoteHostName;

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpServerConnection.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpServerConnection.cs
@@ -17,7 +17,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
     {
         internal TcpServerConnection(ProxyServer proxyServer, TcpClient tcpClient, CustomBufferedStream stream,
             string hostName, int port, bool isHttps, SslApplicationProtocol negotiatedApplicationProtocol,
-            Version version, bool useUpstreamProxy, IExternalProxy? upStreamProxy, IPEndPoint? upStreamEndPoint, string cacheKey)
+            Version version, bool useUpstreamProxy, ExternalProxy? upStreamProxy, IPEndPoint? upStreamEndPoint, string cacheKey)
         {
             this.tcpClient = tcpClient;
             LastAccess = DateTime.Now;
@@ -41,7 +41,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
         internal bool IsClosed => Stream.IsClosed;
 
-        internal IExternalProxy? UpStreamProxy { get; set; }
+        internal ExternalProxy? UpStreamProxy { get; set; }
 
         internal string HostName { get; set; }
 

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpServerConnection.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpServerConnection.cs
@@ -17,7 +17,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
     {
         internal TcpServerConnection(ProxyServer proxyServer, TcpClient tcpClient, CustomBufferedStream stream,
             string hostName, int port, bool isHttps, SslApplicationProtocol negotiatedApplicationProtocol,
-            Version version, bool useUpstreamProxy, ExternalProxy? upStreamProxy, IPEndPoint? upStreamEndPoint, string cacheKey)
+            Version version, bool useUpstreamProxy, IExternalProxy? upStreamProxy, IPEndPoint? upStreamEndPoint, string cacheKey)
         {
             this.tcpClient = tcpClient;
             LastAccess = DateTime.Now;
@@ -41,7 +41,7 @@ namespace Titanium.Web.Proxy.Network.Tcp
 
         internal bool IsClosed => Stream.IsClosed;
 
-        internal ExternalProxy? UpStreamProxy { get; set; }
+        internal IExternalProxy? UpStreamProxy { get; set; }
 
         internal string HostName { get; set; }
 

--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -61,7 +61,7 @@ namespace Titanium.Web.Proxy
         /// </summary>
         private WinHttpWebProxyFinder? systemProxyResolver;
 
-
+        
         /// <inheritdoc />
         /// <summary>
         ///     Initializes a new instance of ProxyServer class with provided parameters.
@@ -145,7 +145,7 @@ namespace Titanium.Web.Proxy
         ///     Defaults to false.
         /// </summary>
         public bool EnableWinAuth { get; set; }
-
+        
         /// <summary>
         ///     Enable disable HTTP/2 support.
         ///     Warning: HTTP/2 support is very limited
@@ -253,12 +253,12 @@ namespace Titanium.Web.Proxy
         /// <summary>
         ///     External proxy used for Http requests.
         /// </summary>
-        public IExternalProxy? UpStreamHttpProxy { get; set; }
+        public ExternalProxy? UpStreamHttpProxy { get; set; }
 
         /// <summary>
         ///     External proxy used for Https requests.
         /// </summary>
-        public IExternalProxy? UpStreamHttpsProxy { get; set; }
+        public ExternalProxy? UpStreamHttpsProxy { get; set; }
 
         /// <summary>
         ///     Local adapter/NIC endpoint where proxy makes request via.
@@ -275,7 +275,7 @@ namespace Titanium.Web.Proxy
         ///     A callback to provide authentication credentials for up stream proxy this proxy is using for HTTP(S) requests.
         ///     User should return the ExternalProxy object with valid credentials.
         /// </summary>
-        public Func<SessionEventArgsBase, Task<IExternalProxy?>>? GetCustomUpStreamProxyFunc { get; set; }
+        public Func<SessionEventArgsBase, Task<ExternalProxy?>>? GetCustomUpStreamProxyFunc { get; set; }
 
         /// <summary>
         ///     Callback for error events in this proxy instance.
@@ -709,7 +709,7 @@ namespace Titanium.Web.Proxy
         /// </summary>
         /// <param name="sessionEventArgs">The session.</param>
         /// <returns>The external proxy as task result.</returns>
-        private Task<IExternalProxy?> getSystemUpStreamProxy(SessionEventArgsBase sessionEventArgs)
+        private Task<ExternalProxy?> getSystemUpStreamProxy(SessionEventArgsBase sessionEventArgs)
         {
             var proxy = systemProxyResolver!.GetProxy(sessionEventArgs.HttpClient.Request.RequestUri);
             return Task.FromResult(proxy);

--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -61,7 +61,7 @@ namespace Titanium.Web.Proxy
         /// </summary>
         private WinHttpWebProxyFinder? systemProxyResolver;
 
-        
+
         /// <inheritdoc />
         /// <summary>
         ///     Initializes a new instance of ProxyServer class with provided parameters.
@@ -145,7 +145,7 @@ namespace Titanium.Web.Proxy
         ///     Defaults to false.
         /// </summary>
         public bool EnableWinAuth { get; set; }
-        
+
         /// <summary>
         ///     Enable disable HTTP/2 support.
         ///     Warning: HTTP/2 support is very limited
@@ -253,12 +253,12 @@ namespace Titanium.Web.Proxy
         /// <summary>
         ///     External proxy used for Http requests.
         /// </summary>
-        public ExternalProxy? UpStreamHttpProxy { get; set; }
+        public IExternalProxy? UpStreamHttpProxy { get; set; }
 
         /// <summary>
         ///     External proxy used for Https requests.
         /// </summary>
-        public ExternalProxy? UpStreamHttpsProxy { get; set; }
+        public IExternalProxy? UpStreamHttpsProxy { get; set; }
 
         /// <summary>
         ///     Local adapter/NIC endpoint where proxy makes request via.
@@ -275,7 +275,7 @@ namespace Titanium.Web.Proxy
         ///     A callback to provide authentication credentials for up stream proxy this proxy is using for HTTP(S) requests.
         ///     User should return the ExternalProxy object with valid credentials.
         /// </summary>
-        public Func<SessionEventArgsBase, Task<ExternalProxy?>>? GetCustomUpStreamProxyFunc { get; set; }
+        public Func<SessionEventArgsBase, Task<IExternalProxy?>>? GetCustomUpStreamProxyFunc { get; set; }
 
         /// <summary>
         ///     Callback for error events in this proxy instance.
@@ -709,7 +709,7 @@ namespace Titanium.Web.Proxy
         /// </summary>
         /// <param name="sessionEventArgs">The session.</param>
         /// <returns>The external proxy as task result.</returns>
-        private Task<ExternalProxy?> getSystemUpStreamProxy(SessionEventArgsBase sessionEventArgs)
+        private Task<IExternalProxy?> getSystemUpStreamProxy(SessionEventArgsBase sessionEventArgs)
         {
             var proxy = systemProxyResolver!.GetProxy(sessionEventArgs.HttpClient.Request.RequestUri);
             return Task.FromResult(proxy);

--- a/tests/Titanium.Web.Proxy.IntegrationTests/NestedProxyTests.cs
+++ b/tests/Titanium.Web.Proxy.IntegrationTests/NestedProxyTests.cs
@@ -69,7 +69,7 @@ namespace Titanium.Web.Proxy.IntegrationTests
             };
 
             var client = testSuite.GetClient(proxy1, true);
-            
+
             var response = await client.PostAsync(new Uri(server.ListeningHttpsUrl),
                                         new StringContent("hello server. I am a client."));
 

--- a/tests/Titanium.Web.Proxy.IntegrationTests/NestedProxyTests.cs
+++ b/tests/Titanium.Web.Proxy.IntegrationTests/NestedProxyTests.cs
@@ -69,7 +69,7 @@ namespace Titanium.Web.Proxy.IntegrationTests
             };
 
             var client = testSuite.GetClient(proxy1, true);
-
+            
             var response = await client.PostAsync(new Uri(server.ListeningHttpsUrl),
                                         new StringContent("hello server. I am a client."));
 


### PR DESCRIPTION
Changes ExternalProxy params to IExternalProxy so a custom class can be used when needed and makes ExternalProxy use IExternalProxy. ExternalProxy is still used as a default class internally.


Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the master branch 
