### PR TITLE
Add support for connect timeout

### DIFF
--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -197,6 +197,12 @@ namespace Titanium.Web.Proxy
         public int ConnectionTimeOutSeconds { get; set; } = 60;
 
         /// <summary>
+        ///     Seconds server connection are to wait for connection to be established.
+        ///     Default value is 20 seconds.
+        /// </summary>
+        public int ConnectTimeOutSeconds { get; set; } = 20;
+
+        /// <summary>
         ///     Maximum number of concurrent connections per remote host in cache.
         ///     Only valid when connection pooling is enabled.
         ///     Default value is 2.


### PR DESCRIPTION
If establishing a connection takes longer than ConnectTimeOutSeconds it will try the next address or fail the connect instead of waiting for the default timeout which is usually 20-30 seconds. Most users will want to change this to something reasonable like 6-10 seconds but to stick with normal operation the default is set to 20 seconds.

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the master branch 
