### PR TITLE
Adds ability to handle upstream proxy connect failures

### DIFF
--- a/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -42,6 +42,10 @@ namespace Titanium.Web.Proxy.Examples.Basic
             proxyServer.ForwardToUpstreamGateway = true;
             proxyServer.CertificateManager.SaveFakeCertificates = true;
 
+            // this is just to show the functionality, provided implementations use junk value
+            //proxyServer.GetCustomUpStreamProxyFunc = onGetCustomUpStreamProxyFunc;
+            //proxyServer.CustomUpStreamProxyFailureFunc = onCustomUpStreamProxyFailureFunc;
+
             // optionally set the Certificate Engine
             // Under Mono or Non-Windows runtimes only BouncyCastle will be supported
             //proxyServer.CertificateManager.CertificateEngine = Network.CertificateEngine.BouncyCastle;
@@ -114,6 +118,18 @@ namespace Titanium.Web.Proxy.Examples.Basic
 
             // remove the generated certificates
             //proxyServer.CertificateManager.RemoveTrustedRootCertificates();
+        }
+
+        private async Task<IExternalProxy> onGetCustomUpStreamProxyFunc(SessionEventArgsBase arg)
+        {
+            // this is just to show the functionality, provided values are junk
+            return new ExternalProxy() { BypassLocalhost = false, HostName = "127.0.0.9", Port = 9090, Password = "fake", UserName = "fake", UseDefaultCredentials = false };
+        }
+
+        private async Task<IExternalProxy> onCustomUpStreamProxyFailureFunc(SessionEventArgsBase arg)
+        {
+            // this is just to show the functionality, provided values are junk
+            return new ExternalProxy() { BypassLocalhost = false, HostName = "127.0.0.10", Port = 9191, Password = "fake2", UserName = "fake2", UseDefaultCredentials = false };
         }
 
         private async Task onBeforeTunnelConnectRequest(object sender, TunnelConnectSessionEventArgs e)

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -397,6 +397,16 @@ retry:
 
                 if (tcpClient == null)
                 {
+                    if (session != null && proxyServer.CustomUpStreamProxyFailureFunc != null)
+                    {
+                        var newUpstreamProxy = await proxyServer.CustomUpStreamProxyFailureFunc(session);
+                        if (newUpstreamProxy != null)
+                        {
+                            session.CustomUpStreamProxyUsed = newUpstreamProxy;
+                            session.TimeLine["Retrying Upstream Proxy Connection"] = DateTime.Now;
+                            return await createServerConnection(remoteHostName, remotePort, httpVersion, isHttps, sslProtocol, applicationProtocols, isConnect, proxyServer, session, upStreamEndPoint, externalProxy, cacheKey, cancellationToken);
+                        }
+                    }
                     throw new Exception($"Could not establish connection to {hostname}", lastException);
                 }
 

--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -284,6 +284,12 @@ namespace Titanium.Web.Proxy
         public Func<SessionEventArgsBase, Task<IExternalProxy?>>? GetCustomUpStreamProxyFunc { get; set; }
 
         /// <summary>
+        ///     A callback to provide a chance for an upstream proxy failure to be handled by a new upstream proxy.
+        ///     User should return the ExternalProxy object with valid credentials or null.
+        /// </summary>
+        public Func<SessionEventArgsBase, Task<IExternalProxy?>>? CustomUpStreamProxyFailureFunc { get; set; }
+
+        /// <summary>
         ///     Callback for error events in this proxy instance.
         /// </summary>
         public ExceptionHandler ExceptionFunc


### PR DESCRIPTION
Adds ability to handle upstream proxy connect failures by using a new upstream proxy if the user provides one. I'm not sure if this is how you would do this @honfika so lmk...

closes #646 

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the master branch 
