### PR TITLE
Keep track of how many upstream proxies have been tried

### DIFF
--- a/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -128,7 +128,7 @@ namespace Titanium.Web.Proxy.Examples.Basic
 
         private async Task<IExternalProxy> onCustomUpStreamProxyFailureFunc(SessionEventArgsBase arg)
         {
-            if (arg.CustomUpstreamProxyTries < 2) // try a max of 2 extra times to get a connection
+            if (arg.CustomUpStreamProxyTries < 2) // try a max of 2 extra times to get a connection
             {
                 // this is just to show the functionality, provided values are junk
                 return new ExternalProxy() { BypassLocalhost = false, HostName = "127.0.0.10", Port = 9191, Password = "fake2", UserName = "fake2", UseDefaultCredentials = false };

--- a/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -43,8 +43,8 @@ namespace Titanium.Web.Proxy.Examples.Basic
             proxyServer.CertificateManager.SaveFakeCertificates = true;
 
             // this is just to show the functionality, provided implementations use junk value
-            //proxyServer.GetCustomUpStreamProxyFunc = onGetCustomUpStreamProxyFunc;
-            //proxyServer.CustomUpStreamProxyFailureFunc = onCustomUpStreamProxyFailureFunc;
+            proxyServer.GetCustomUpStreamProxyFunc = onGetCustomUpStreamProxyFunc;
+            proxyServer.CustomUpStreamProxyFailureFunc = onCustomUpStreamProxyFailureFunc;
 
             // optionally set the Certificate Engine
             // Under Mono or Non-Windows runtimes only BouncyCastle will be supported
@@ -128,8 +128,14 @@ namespace Titanium.Web.Proxy.Examples.Basic
 
         private async Task<IExternalProxy> onCustomUpStreamProxyFailureFunc(SessionEventArgsBase arg)
         {
-            // this is just to show the functionality, provided values are junk
-            return new ExternalProxy() { BypassLocalhost = false, HostName = "127.0.0.10", Port = 9191, Password = "fake2", UserName = "fake2", UseDefaultCredentials = false };
+            if (arg.CustomUpstreamProxyTries < 2) // try a max of 2 extra times to get a connection
+            {
+                // this is just to show the functionality, provided values are junk
+                return new ExternalProxy() { BypassLocalhost = false, HostName = "127.0.0.10", Port = 9191, Password = "fake2", UserName = "fake2", UseDefaultCredentials = false };
+            }
+
+            // we have reached our max retries so just bail out by not returning a new proxy
+            return null;
         }
 
         private async Task onBeforeTunnelConnectRequest(object sender, TunnelConnectSessionEventArgs e)

--- a/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
+++ b/examples/Titanium.Web.Proxy.Examples.Basic/ProxyTestController.cs
@@ -43,8 +43,8 @@ namespace Titanium.Web.Proxy.Examples.Basic
             proxyServer.CertificateManager.SaveFakeCertificates = true;
 
             // this is just to show the functionality, provided implementations use junk value
-            proxyServer.GetCustomUpStreamProxyFunc = onGetCustomUpStreamProxyFunc;
-            proxyServer.CustomUpStreamProxyFailureFunc = onCustomUpStreamProxyFailureFunc;
+            //proxyServer.GetCustomUpStreamProxyFunc = onGetCustomUpStreamProxyFunc;
+            //proxyServer.CustomUpStreamProxyFailureFunc = onCustomUpStreamProxyFailureFunc;
 
             // optionally set the Certificate Engine
             // Under Mono or Non-Windows runtimes only BouncyCastle will be supported

--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
@@ -125,6 +125,12 @@ namespace Titanium.Web.Proxy.EventArguments
         public Exception? Exception { get; internal set; }
 
         /// <summary>
+        ///     The number of tries that have been done to connect to a custom upstream proxy.
+        ///     This could use a more declarative name but idk what that is at the moment!
+        /// </summary>
+        public int CustomUpstreamProxyTries { get; internal set; }
+
+        /// <summary>
         ///     Implements cleanup here.
         /// </summary>
         public virtual void Dispose()

--- a/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/SessionEventArgsBase.cs
@@ -128,7 +128,7 @@ namespace Titanium.Web.Proxy.EventArguments
         ///     The number of tries that have been done to connect to a custom upstream proxy.
         ///     This could use a more declarative name but idk what that is at the moment!
         /// </summary>
-        public int CustomUpstreamProxyTries { get; internal set; }
+        public int CustomUpStreamProxyTries { get; internal set; }
 
         /// <summary>
         ///     Implements cleanup here.

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -399,6 +399,8 @@ retry:
                 {
                     if (session != null && proxyServer.CustomUpStreamProxyFailureFunc != null)
                     {
+                        session.CustomUpstreamProxyTries++;
+
                         var newUpstreamProxy = await proxyServer.CustomUpStreamProxyFailureFunc(session);
                         if (newUpstreamProxy != null)
                         {

--- a/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
+++ b/src/Titanium.Web.Proxy/Network/Tcp/TcpConnectionFactory.cs
@@ -399,7 +399,7 @@ retry:
                 {
                     if (session != null && proxyServer.CustomUpStreamProxyFailureFunc != null)
                     {
-                        session.CustomUpstreamProxyTries++;
+                        session.CustomUpStreamProxyTries++;
 
                         var newUpstreamProxy = await proxyServer.CustomUpStreamProxyFailureFunc(session);
                         if (newUpstreamProxy != null)


### PR DESCRIPTION
Makes it easy to keep track of how many upstream proxies have been tried.

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the master branch 
