### PR TITLE
.Net45 compatibility returns a finished task

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/Net45Compatibility.cs
+++ b/src/Titanium.Web.Proxy/Helpers/Net45Compatibility.cs
@@ -8,7 +8,7 @@ namespace Titanium.Web.Proxy
     {
         public static byte[] EmptyArray = new byte[0];
 
-        public static Task CompletedTask = new Task(() => { });
+        public static Task CompletedTask = Task.FromResult<object>(null);
     }
 }
 #endif


### PR DESCRIPTION
awaiting `new Task(() => { })` never finishes since the task is never started

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the master branch 
