### PR TITLE
Update the TLS version used in TransparentClientHandler.cs

### DIFF
--- a/src/Titanium.Web.Proxy/TransparentClientHandler.cs
+++ b/src/Titanium.Web.Proxy/TransparentClientHandler.cs
@@ -71,7 +71,7 @@ namespace Titanium.Web.Proxy
                                                     await CertificateManager.CreateServerCertificate(certName);
 
                             // Successfully managed to authenticate the client using the certificate
-                            await sslStream.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls, false);
+                            await sslStream.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
 
                             // HTTPS server created - we can now decrypt the client's traffic
                             clientStream = new HttpClientStream(clientStream.Connection, sslStream, BufferPool, cancellationToken);


### PR DESCRIPTION
Doneness:
- [ x] Build is okay - I made sure that this change is building successfully.
- [x ] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ x] Branching - If this is not a hotfix, I am making this request against the master branch 

I found that using Titanium as a reverse proxy doesn't work with HTTPS unless you update the TLS version to 1.2 because most browsers are not accepting the older version used as default.