### PR TITLE
If the RequestUri in Http.Request is set with an escaped URI then the…

### DIFF
--- a/src/Titanium.Web.Proxy/Http/Request.cs
+++ b/src/Titanium.Web.Proxy/Http/Request.cs
@@ -59,7 +59,7 @@ namespace Titanium.Web.Proxy.Http
             }
             set
             {
-                Url = value.ToString();
+                Url = value.AbsoluteUri;
             }
         }
 


### PR DESCRIPTION
If the RequestUri in Http.Request is set with an escaped URI then the backing string 'Url' will get an unescaped URI, which is incorrect.

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [ ] Branching - If this is not a hotfix, I am making this request against the master branch 
