### PR TITLE
Cannot assign to 'TrustRootCertificate' because it is a 'method group'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Setup HTTP proxy:
 var proxyServer = new ProxyServer();
 
 // locally trust root certificate used by this proxy 
-proxyServer.CertificateManager.TrustRootCertificate = true;
+proxyServer.CertificateManager.TrustRootCertificate(true);
 
 // optionally set the Certificate Engine
 // Under Mono only BouncyCastle will be supported


### PR DESCRIPTION
Doneness:
- [✔️] Build is okay - I made sure that this change is building successfully.
- [✔️] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [✔️] Branching - If this is not a hotfix, I am making this request against the develop branch 
