### PR TITLE
Added parameter to Start controlling if system proxy settings should be cleared.

### DIFF
--- a/src/Titanium.Web.Proxy/ProxyServer.cs
+++ b/src/Titanium.Web.Proxy/ProxyServer.cs
@@ -586,7 +586,11 @@ namespace Titanium.Web.Proxy
         /// <summary>
         ///     Start this proxy server instance.
         /// </summary>
-        public void Start()
+        /// <param name="changeSystemProxySettings"> 
+        ///     Whether or not clear any system proxy settings which is pointing to our own endpoint (causing a cycle).
+        ///     E.g due to ungracious proxy shutdown before.
+        /// </param>
+        public void Start(bool changeSystemProxySettings = true)
         {
             if (ProxyRunning)
             {
@@ -600,9 +604,7 @@ namespace Titanium.Web.Proxy
                 CertificateManager.EnsureRootCertificate();
             }
 
-            // clear any system proxy settings which is pointing to our own endpoint (causing a cycle)
-            // due to ungracious proxy shutdown before or something else
-            if (systemProxySettingsManager != null && RunTime.IsWindows && !RunTime.IsUwpOnWindows)
+            if (changeSystemProxySettings && systemProxySettingsManager != null && RunTime.IsWindows && !RunTime.IsUwpOnWindows)
             {
                 var proxyInfo = systemProxySettingsManager.GetProxyInfoFromRegistry();
                 if (proxyInfo?.Proxies != null)


### PR DESCRIPTION
Purpose of this parameter is to enable proxy to be run on system startup reusing previously set port on system where user cannot change proxy settings due to admin restrictions.

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the develop branch 
