### PR TITLE
Fix for #769: Wildcard bug on second-level domain

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/HttpHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/HttpHelper.cs
@@ -152,7 +152,7 @@ namespace Titanium.Web.Proxy.Helpers
             {
                 // issue #769
                 // do not create wildcard if second level domain like: .ac.id, .co.id
-                string[] prefix = hostname.Split('.');
+                string[] prefix = hostname.Split(ProxyConstants.DotSplit);
                 if (prefix[1].Length <= 3)
                 {
                     return hostname;

--- a/src/Titanium.Web.Proxy/Helpers/HttpHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/HttpHelper.cs
@@ -150,6 +150,14 @@ namespace Titanium.Web.Proxy.Helpers
 
             if (hostname.Split(ProxyConstants.DotSplit).Length > 2)
             {
+                // issue #769
+                // do not create wildcard if second level domain like: .ac.id, .co.id
+                string[] prefix = hostname.Split('.');
+                if (prefix[1].Length <= 3)
+                {
+                    return hostname;
+                }
+                
                 int idx = hostname.IndexOf(ProxyConstants.DotSplit);
 
                 // issue #352


### PR DESCRIPTION
When openning second-level domain like ".ac.id, .co.id, .vn.ua, etc" it will show message "Couldn't authenticate host".
Issue #769 

Doneness:
- [x] Build is okay - I made sure that this change is building successfully.
- [x] No Bugs - I made sure that this change is working properly as expected. It doesn't have any bugs that you are aware of. 
- [x] Branching - If this is not a hotfix, I am making this request against the develop branch 
