### PR TITLE
Handle 407 Proxy Authentication Required

### DIFF
--- a/src/Titanium.Web.Proxy/Network/WinAuth/Security/Common.cs
+++ b/src/Titanium.Web.Proxy/Network/WinAuth/Security/Common.cs
@@ -8,19 +8,12 @@ internal class Common
     internal static uint NewContextAttributes = 0;
     internal static SecurityInteger NewLifeTime = new(0);
 
-    #region Private constants
+    #region Internal constants
 
-    private const int IscReqReplayDetect = 0x00000004;
-    private const int IscReqSequenceDetect = 0x00000008;
-    private const int IscReqConfidentiality = 0x00000010;
-    private const int IscReqConnection = 0x00000800;
-
-    #endregion
-
-    #region internal constants
-
-    internal const int StandardContextAttributes =
-        IscReqConfidentiality | IscReqReplayDetect | IscReqSequenceDetect | IscReqConnection;
+    internal const int IscReqReplayDetect = 0x00000004;
+    internal const int IscReqSequenceDetect = 0x00000008;
+    internal const int IscReqConfidentiality = 0x00000010;
+    internal const int IscReqConnection = 0x00000800;
 
     internal const int SecurityNativeDataRepresentation = 0x10;
     internal const int MaximumTokenSize = 12288;
@@ -160,13 +153,13 @@ internal class Common
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct SecurityBufferDesciption
+    internal struct SecurityBufferDescription
     {
         internal int ulVersion;
         internal int cBuffers;
         internal IntPtr pBuffers; // Point to SecBuffer
 
-        internal SecurityBufferDesciption(int bufferSize)
+        internal SecurityBufferDescription(int bufferSize)
         {
             ulVersion = (int)SecurityBufferType.SecbufferVersion;
             cBuffers = 1;
@@ -175,7 +168,7 @@ internal class Common
             Marshal.StructureToPtr(thisSecBuffer, pBuffers, false);
         }
 
-        internal SecurityBufferDesciption(byte[] secBufferBytes)
+        internal SecurityBufferDescription(byte[] secBufferBytes)
         {
             ulVersion = (int)SecurityBufferType.SecbufferVersion;
             cBuffers = 1;

--- a/src/Titanium.Web.Proxy/Network/WinAuth/WinAuthHandler.cs
+++ b/src/Titanium.Web.Proxy/Network/WinAuth/WinAuthHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Titanium.Web.Proxy.Http;
 using Titanium.Web.Proxy.Network.WinAuth.Security;
+using static Titanium.Web.Proxy.Network.WinAuth.Security.Common;
 
 namespace Titanium.Web.Proxy.Network.WinAuth;
 
@@ -21,7 +22,10 @@ internal static class WinAuthHandler
     /// <returns></returns>
     internal static string GetInitialAuthToken(string serverHostname, string authScheme, InternalDataStore data)
     {
-        var tokenBytes = WinAuthEndPoint.AcquireInitialSecurityToken(serverHostname, authScheme, data);
+        var tokenBytes = WinAuthEndPoint.AcquireInitialSecurityToken(serverHostname,
+            authScheme,
+            data,
+            IscReqConfidentiality | IscReqReplayDetect | IscReqSequenceDetect | IscReqConnection);
         return string.Concat(" ", Convert.ToBase64String(tokenBytes));
     }
 
@@ -35,8 +39,52 @@ internal static class WinAuthHandler
     internal static string GetFinalAuthToken(string serverHostname, string serverToken, InternalDataStore data)
     {
         var tokenBytes =
-            WinAuthEndPoint.AcquireFinalSecurityToken(serverHostname, Convert.FromBase64String(serverToken),
-                data);
+            WinAuthEndPoint.AcquireFinalSecurityToken(serverHostname,
+                Convert.FromBase64String(serverToken),
+                data,
+                IscReqConfidentiality | IscReqReplayDetect | IscReqSequenceDetect | IscReqConnection);
+
+        return string.Concat(" ", Convert.ToBase64String(tokenBytes));
+    }
+
+    // NTLM authentication with the proxy server works in a different way and different ISC_REQ_* flags need to be passed
+    // Chromium sets ISC_REQ_DELEGATE | ISC_REQ_MUTUAL_AUTH as seen in https://chromium.googlesource.com/chromium/src/net/+/b8c947c21ffb46f616ece1948ba0545e671cf23e/http/http_auth_sspi_win.cc#546
+    // cURL uses no flags since commit https://github.com/curl/curl/commit/8ee182288af1bd828613fdcab2e7e8b551e91901 (now moved in lib/vauth/ntlm_sspi.c)
+    // .NET since 6.0.4 has chosen ISC_REQ_CONNECTION https://github.com/dotnet/runtime/pull/66305/files
+    // CNTLM (the new maintained version) instead passes ISC_REQ_CONFIDENTIALITY | ISC_REQ_REPLAY_DETECT | ISC_REQ_CONNECTION https://github.com/versat/cntlm/blob/d6a47bb5c2489503e3d97e52685b8dc10300da96/sspi.c#L239
+    // This is Microsoft documentation for the InitializeSecurityContext function https://learn.microsoft.com/en-us/windows/win32/secauthn/initializesecuritycontext--general
+    // The whole thing seems pretty randomic...
+
+    /// <summary>
+    ///     Get the initial client token for proxy server
+    ///     using credentials of user running the proxy server process
+    /// </summary>
+    /// <param name="proxyHostname"></param>
+    /// <param name="authScheme"></param>
+    /// <param name="data"></param>
+    /// <returns></returns>
+    internal static string GetInitialProxyAuthToken(string proxyHostname, string authScheme, InternalDataStore data)
+    {
+        var tokenBytes = WinAuthEndPoint.AcquireInitialSecurityToken(proxyHostname,
+            authScheme,
+            data,
+            0);
+        return string.Concat(" ", Convert.ToBase64String(tokenBytes));
+    }
+
+    /// <summary>
+    ///     Get the final token given the proxy server challenge token
+    /// </summary>
+    /// <param name="proxyHostname"></param>
+    /// <param name="serverToken"></param>
+    /// <param name="data"></param>
+    /// <returns></returns>
+    internal static string GetFinalProxyAuthToken(string proxyHostname, string serverToken, InternalDataStore data)
+    {
+        var tokenBytes = WinAuthEndPoint.AcquireFinalSecurityToken(proxyHostname,
+            Convert.FromBase64String(serverToken),
+            data,
+            0);
 
         return string.Concat(" ", Convert.ToBase64String(tokenBytes));
     }

--- a/src/Titanium.Web.Proxy/RequestHandler.cs
+++ b/src/Titanium.Web.Proxy/RequestHandler.cs
@@ -372,7 +372,7 @@ public partial class ProxyServer
     /// <summary>
     ///     Invoke before request handler if it is set.
     /// </summary>
-    /// <param name="request">The COONECT request.</param>
+    /// <param name="request">The CONNECT request.</param>
     /// <returns></returns>
     internal async Task OnBeforeUpStreamConnectRequest(ConnectRequest request)
     {


### PR DESCRIPTION
I'm currently working on implementing the feature described in #944. So far I've made it working for plain HTTP requests and I still need to figure out how to do it for HTTPS CONNECTs. Any help is appreciated, especially regarding a better integration in the huge code base and handling of edge cases.