### PR TITLE
Raise develop new-code coverage above 80% (pass 2)

### DIFF
--- a/tests/Titanium.Web.Proxy.IntegrationTests/Helpers/QuicHttp3Helpers.cs
+++ b/tests/Titanium.Web.Proxy.IntegrationTests/Helpers/QuicHttp3Helpers.cs
@@ -158,11 +158,14 @@ internal sealed class QuicHttp3OriginServer : IAsyncDisposable
                 }
 
                 var response = await handler(new QuicHttp3Request(method, path, authority, body.ToArray()));
-                var responseHeaders = QpackEncoder.Encode(new List<(string, string)>
+                var headerList = new List<(string, string)>
                 {
                     (":status", response.StatusCode.ToString()),
-                    ("content-type", "text/plain")
-                });
+                    ("content-type", response.ContentType ?? "text/plain")
+                };
+                if (response.ExtraHeaders != null)
+                    headerList.AddRange(response.ExtraHeaders);
+                var responseHeaders = QpackEncoder.Encode(headerList);
                 await Http3Frame.WriteAsync(stream, Http3FrameType.Headers, responseHeaders, cts.Token);
                 if (response.Body is { Length: > 0 })
                     await Http3Frame.WriteAsync(stream, Http3FrameType.Data, response.Body, cts.Token);
@@ -337,16 +340,21 @@ internal sealed class QuicHttp3Response
     {
     }
 
-    public QuicHttp3Response(int statusCode, string textBody, byte[] body)
+    public QuicHttp3Response(int statusCode, string textBody, byte[] body,
+        IReadOnlyList<(string Name, string Value)>? extraHeaders = null, string? contentType = null)
     {
         StatusCode = statusCode;
         TextBody = textBody;
         Body = body;
+        ExtraHeaders = extraHeaders;
+        ContentType = contentType;
     }
 
     public int StatusCode { get; }
     public string TextBody { get; }
     public byte[] Body { get; }
+    public IReadOnlyList<(string Name, string Value)>? ExtraHeaders { get; }
+    public string? ContentType { get; }
 }
 
 #pragma warning restore TWP001

--- a/tests/Titanium.Web.Proxy.IntegrationTests/Http3BridgeTests.cs
+++ b/tests/Titanium.Web.Proxy.IntegrationTests/Http3BridgeTests.cs
@@ -2,6 +2,7 @@
 #pragma warning disable TWP001
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Quic;
@@ -258,6 +259,79 @@ public class Http3BridgeTests
 
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, body);
         Assert.AreEqual("cold-tcp-fallback", body);
+    }
+
+    [TestMethod]
+    public async Task Http11Client_ForcedHttp3_UnreachableOrigin_Returns502()
+    {
+        RequireQuic();
+
+        // Bind then close so the port is almost certainly closed when the proxy dials QUIC.
+        int closedPort;
+        await using (var ephemeral = new QuicHttp3OriginServer(TestCertificateAuthority.ServerCertificate))
+            closedPort = ephemeral.Port;
+
+        using var testSuite = new TestSuite();
+        var proxy = testSuite.GetProxy();
+        proxy.EnableHttp3 = true;
+        proxy.EnableHttpsSvcbDnsDiscovery = false;
+        proxy.BeforeRequest += (_, args) =>
+        {
+            args.UpstreamHttpProtocol = UpstreamHttpProtocol.Http3;
+            return Task.CompletedTask;
+        };
+
+        using var client = testSuite.GetClient(proxy);
+        var response = await client.GetAsync($"https://localhost:{closedPort}/gone");
+        Assert.AreEqual(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Http11Client_ForcedHttp3Origin_GzipBody_SurvivesBridgeWithoutCorruption()
+    {
+        RequireQuic();
+
+        var plain = Encoding.UTF8.GetBytes("gzip-plain");
+        byte[] gzipped;
+        using (var ms = new System.IO.MemoryStream())
+        {
+            using (var gzip = new System.IO.Compression.GZipStream(ms, System.IO.Compression.CompressionLevel.SmallestSize, leaveOpen: true))
+                gzip.Write(plain);
+            gzipped = ms.ToArray();
+        }
+
+        await using var origin = new QuicHttp3OriginServer(TestCertificateAuthority.ServerCertificate);
+        origin.HandleRequest(_ => Task.FromResult(new QuicHttp3Response(
+            200, "gzip-plain", gzipped,
+            extraHeaders: new List<(string, string)> { ("content-encoding", "gzip") })));
+
+        using var testSuite = new TestSuite();
+        var proxy = testSuite.GetProxy();
+        proxy.EnableHttp3 = true;
+        proxy.EnableHttpsSvcbDnsDiscovery = false;
+        proxy.BeforeRequest += (_, args) =>
+        {
+            args.UpstreamHttpProtocol = UpstreamHttpProtocol.Http3;
+            return Task.CompletedTask;
+        };
+
+        // AutomaticDecompression exercises the bridge's decompress-then-recompress path:
+        // H3OriginBridge decompresses wire bytes so CompressBodyAndUpdateContentLength can
+        // safely re-apply Content-Encoding for the H1 client without double-compressing.
+        using var handler = new HttpClientHandler
+        {
+            Proxy = new TestHelper.TestProxy($"http://localhost:{proxy.ProxyEndPoints[0].Port}", false),
+            UseProxy = true,
+            AutomaticDecompression = DecompressionMethods.GZip,
+            ServerCertificateCustomValidationCallback =
+                (_, certificate, _, errors) => TestCertificateAuthority.Validate(certificate, errors)
+        };
+        using var client = new HttpClient(handler);
+        var response = await client.GetAsync($"https://localhost:{origin.Port}/gzip");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, body);
+        Assert.AreEqual("gzip-plain", body);
     }
 }
 

--- a/tests/Titanium.Web.Proxy.UnitTests/CompressionUtilChainTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/CompressionUtilChainTests.cs
@@ -1,14 +1,42 @@
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Titanium.Web.Proxy.Compression;
+using Titanium.Web.Proxy.Http;
 
 namespace Titanium.Web.Proxy.UnitTests;
 
 [TestClass]
 public class CompressionUtilChainTests
 {
+    [TestMethod]
+    public void CompressionFactory_Create_KnownKinds_RoundTripThroughDecompressionFactory()
+    {
+        var plain = Encoding.UTF8.GetBytes("factory-bytes");
+        foreach (var kind in new[] { HttpCompression.Gzip, HttpCompression.Deflate, HttpCompression.Brotli })
+        {
+            using var compressed = new MemoryStream();
+            using (var encoder = CompressionFactory.Create(kind, compressed, leaveOpen: true))
+                encoder.Write(plain);
+
+            compressed.Position = 0;
+            using var decoder = DecompressionFactory.Create(kind, compressed, leaveOpen: true);
+            using var decoded = new MemoryStream();
+            decoder.CopyTo(decoded);
+            CollectionAssert.AreEqual(plain, decoded.ToArray(), $"Failed for {kind}");
+        }
+    }
+
+    [TestMethod]
+    public void CompressionFactory_Unsupported_Throws()
+    {
+        using var ms = new MemoryStream();
+        Assert.ThrowsException<Exception>(() => CompressionFactory.Create(HttpCompression.Unsupported, ms));
+        Assert.ThrowsException<Exception>(() => DecompressionFactory.Create(HttpCompression.Unsupported, ms));
+    }
+
     [TestMethod]
     public void CreateDecompressionChain_EmptyOrWhitespace_Passthrough()
     {

--- a/tests/Titanium.Web.Proxy.UnitTests/DefaultCertificateDiskCacheTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/DefaultCertificateDiskCacheTests.cs
@@ -118,6 +118,27 @@ public class DefaultCertificateDiskCacheTests
     }
 
     [TestMethod]
+    public void CertificateLoader_LoadCertificate_AndLoadPkcs12_RoundTrip()
+    {
+        using var mgr = new CertificateManager(null, null, false, false, false, NullLogger.Instance)
+        {
+            CertificateEngine = CertificateEngine.BouncyCastleFast
+        };
+        Assert.IsTrue(mgr.CreateRootCertificate(false));
+        using var cert = mgr.CreateCertificate("loader.example", false);
+
+        var raw = cert.Export(X509ContentType.Cert);
+        using var loaded = Titanium.Web.Proxy.Network.Certificate.CertificateLoader.LoadCertificate(raw);
+        Assert.AreEqual(cert.Thumbprint, loaded.Thumbprint);
+
+        var pfx = cert.Export(X509ContentType.Pkcs12, "pw");
+        using var loadedPfx = Titanium.Web.Proxy.Network.Certificate.CertificateLoader.LoadPkcs12(
+            pfx, "pw", X509KeyStorageFlags.Exportable);
+        Assert.AreEqual(cert.Thumbprint, loadedPfx.Thumbprint);
+        Assert.IsTrue(loadedPfx.HasPrivateKey);
+    }
+
+    [TestMethod]
     public void LoadCertificate_CorruptPfx_ReturnsNull()
     {
         if (!RunTime.IsWindows)

--- a/tests/Titanium.Web.Proxy.UnitTests/Http2HelperFrameWriterTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/Http2HelperFrameWriterTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.Http;
+using Titanium.Web.Proxy.Http2;
+using Titanium.Web.Proxy.Models;
+
+namespace Titanium.Web.Proxy.UnitTests;
+
+/// <summary>
+///     Unit coverage for <see cref="Http2Helper" /> frame writers (RST/GOAWAY/WINDOW_UPDATE/DATA/HEADERS).
+/// </summary>
+[TestClass]
+public class Http2HelperFrameWriterTests
+{
+    private static (Http2FrameHeader Header, byte[] Buffer) NewFrameScratch(int streamId = 1)
+        => (new Http2FrameHeader { StreamId = streamId }, new byte[9]);
+
+    [TestMethod]
+    public async Task SendRstStreamAsync_WritesFourByteErrorCode()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(7);
+
+        await Http2Helper.SendRstStreamAsync(header, buf, 7, Http2ErrorCode.ProtocolError, ms);
+
+        var wire = ms.ToArray();
+        Assert.AreEqual(13, wire.Length); // 9-byte header + 4-byte payload
+        Assert.AreEqual((byte)Http2FrameType.RstStream, wire[3]);
+        Assert.AreEqual(7, (wire[5] << 24) | (wire[6] << 16) | (wire[7] << 8) | wire[8]);
+        Assert.AreEqual((int)Http2ErrorCode.ProtocolError,
+            (wire[9] << 24) | (wire[10] << 16) | (wire[11] << 8) | wire[12]);
+    }
+
+    [TestMethod]
+    public async Task SendRstStreamAsync_NoError_DoesNotRequirePayloadMetrics()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        await Http2Helper.SendRstStreamAsync(header, buf, 1, Http2ErrorCode.NoError, ms);
+        Assert.AreEqual(13, ms.Length);
+    }
+
+    [TestMethod]
+    public async Task SendGoAwayAsync_WritesLastStreamIdAndFlushes()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(0);
+
+        await Http2Helper.SendGoAwayAsync(header, buf, lastStreamId: 5, Http2ErrorCode.ProtocolError, ms);
+
+        var wire = ms.ToArray();
+        Assert.AreEqual(17, wire.Length); // 9 + 8
+        Assert.AreEqual((byte)Http2FrameType.GoAway, wire[3]);
+        Assert.AreEqual(0, (wire[5] << 24) | (wire[6] << 16) | (wire[7] << 8) | wire[8]);
+        Assert.AreEqual(5, (wire[9] << 24) | (wire[10] << 16) | (wire[11] << 8) | wire[12]);
+    }
+
+    [TestMethod]
+    public async Task SendWindowUpdateAsync_ZeroIncrement_IsNoOp()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        await Http2Helper.SendWindowUpdateAsync(header, buf, 1, increment: 0, ms);
+        Assert.AreEqual(0, ms.Length);
+    }
+
+    [TestMethod]
+    public async Task SendWindowUpdateAsync_PositiveIncrement_WritesPayload()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(3);
+        await Http2Helper.SendWindowUpdateAsync(header, buf, 3, increment: 1024, ms);
+
+        var wire = ms.ToArray();
+        Assert.AreEqual(13, wire.Length);
+        Assert.AreEqual((byte)Http2FrameType.WindowUpdate, wire[3]);
+        Assert.AreEqual(1024, (wire[9] << 24) | (wire[10] << 16) | (wire[11] << 8) | wire[12]);
+    }
+
+    [TestMethod]
+    public async Task SendData_EmptyWithEndStream_WritesEmptyDataFrame()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var flow = new Http2FlowController();
+        flow.RegisterStream(1);
+
+        await Http2Helper.SendData(header, buf, 1, Array.Empty<byte>(), endStream: true, maxFrameSize: 16384,
+            flow, ms, CancellationToken.None);
+
+        var wire = ms.ToArray();
+        Assert.AreEqual(9, wire.Length);
+        Assert.AreEqual((byte)Http2FrameType.Data, wire[3]);
+        Assert.AreEqual((byte)Http2FrameFlag.EndStream, wire[4]);
+    }
+
+    [TestMethod]
+    public async Task SendData_SplitsOnMaxFrameSize()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var flow = new Http2FlowController();
+        flow.RegisterStream(1);
+        var payload = new byte[10];
+        for (var i = 0; i < payload.Length; i++) payload[i] = (byte)i;
+
+        await Http2Helper.SendData(header, buf, 1, payload, endStream: true, maxFrameSize: 4,
+            flow, ms, CancellationToken.None);
+
+        // 4 + 4 + 2 payloads → 3 frames × 9 header + 10 payload = 37
+        Assert.AreEqual(37, ms.Length);
+        var wire = ms.ToArray();
+        Assert.AreEqual((byte)Http2FrameType.Data, wire[3]);
+        // Last frame header starts at offset 26; flags at 30
+        Assert.AreEqual((byte)Http2FrameFlag.EndStream, wire[30]);
+    }
+
+    [TestMethod]
+    public async Task SendHeader_Response_LowercasesMixedCaseNames_AndKeepsViaLiteral()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var settings = new Http2Settings { MaxFrameSize = 16384 };
+        var response = new Response
+        {
+            HttpVersion = HttpHeader.Version20,
+            StatusCode = 200,
+            StatusDescription = "OK"
+        };
+        response.Headers.AddHeader("Content-Type", "text/plain");
+        response.Headers.AddHeader("Via", "2.0 proxy");
+
+        await Http2Helper.SendHeader(settings, header, buf, response, endStream: true, ms, pushPromise: false);
+
+        Assert.IsTrue(ms.Length > 9);
+        Assert.IsNotNull(settings.Encoder);
+        Assert.AreEqual((byte)Http2FrameType.Headers, ms.ToArray()[3]);
+        Assert.AreEqual((byte)(Http2FrameFlag.EndHeaders | Http2FrameFlag.EndStream), ms.ToArray()[4]);
+    }
+
+    [TestMethod]
+    public async Task SendHeader_RequestWithPriority_AndDualDtsu_EmitsHeaders()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var settings = new Http2Settings { MaxFrameSize = 16384 };
+        // Force dual DTSU: shrink then grow between encodes.
+        settings.UpdateHeaderTableSize(0);
+        settings.UpdateHeaderTableSize(65536);
+
+        var request = new Request
+        {
+            Method = "GET",
+            HttpVersion = HttpHeader.Version20,
+            IsHttps = true,
+            RequestUriString = "https://example.com/path",
+            Priority = 0x1234567890L
+        };
+
+        await Http2Helper.SendHeader(settings, header, buf, request, endStream: true, ms, pushPromise: false);
+
+        var wire = ms.ToArray();
+        Assert.IsTrue(wire.Length > 9);
+        Assert.AreEqual((byte)Http2FrameType.Headers, wire[3]);
+        Assert.AreEqual((byte)(Http2FrameFlag.EndHeaders | Http2FrameFlag.EndStream | Http2FrameFlag.Priority),
+            wire[4]);
+        Assert.AreEqual(65536, settings.MinHeaderTableSizeSinceLastEncode);
+    }
+
+    [TestMethod]
+    public async Task SendHeader_TinyMaxFrameSize_EmitsContinuationFrames()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var settings = new Http2Settings { MaxFrameSize = 16 };
+        var response = new Response
+        {
+            HttpVersion = HttpHeader.Version20,
+            StatusCode = 200,
+            StatusDescription = "OK"
+        };
+        // Force a header block well above one 16-byte frame.
+        response.Headers.AddHeader("x-long-header", new string('a', 200));
+
+        await Http2Helper.SendHeader(settings, header, buf, response, endStream: false, ms, pushPromise: false);
+
+        var wire = ms.ToArray();
+        Assert.AreEqual((byte)Http2FrameType.Headers, wire[3]);
+        Assert.AreEqual(0, (byte)(wire[4] & (byte)Http2FrameFlag.EndHeaders),
+            "First HEADERS frame must not set END_HEADERS when CONTINUATION follows.");
+
+        var sawContinuation = false;
+        var i = 0;
+        while (i + 9 <= wire.Length)
+        {
+            var len = (wire[i] << 16) | (wire[i + 1] << 8) | wire[i + 2];
+            var type = wire[i + 3];
+            if (type == (byte)Http2FrameType.Continuation)
+                sawContinuation = true;
+            i += 9 + len;
+        }
+
+        Assert.IsTrue(sawContinuation, $"Expected CONTINUATION frames; wire length={wire.Length}");
+    }
+
+    [TestMethod]
+    public async Task SendTrailer_WritesHeadersWithoutPseudoHeaders()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var settings = new Http2Settings();
+        var trailers = new HeaderCollection();
+        trailers.AddHeader("x-trailer", "done");
+
+        await Http2Helper.SendTrailer(settings, header, buf, 1, trailers, endStream: true, ms);
+
+        var wire = ms.ToArray();
+        Assert.IsTrue(wire.Length > 9);
+        Assert.AreEqual((byte)Http2FrameType.Headers, wire[3]);
+        Assert.AreEqual((byte)(Http2FrameFlag.EndHeaders | Http2FrameFlag.EndStream), wire[4]);
+    }
+
+    [TestMethod]
+    public async Task SendData_NonPositiveMaxFrameSize_FallsBackToDefault()
+    {
+        using var ms = new MemoryStream();
+        var (header, buf) = NewFrameScratch(1);
+        var flow = new Http2FlowController();
+        flow.RegisterStream(1);
+        var payload = new byte[20];
+
+        await Http2Helper.SendData(header, buf, 1, payload, endStream: false, maxFrameSize: 0,
+            flow, ms, CancellationToken.None);
+
+        // Single frame (20 < 16384 fallback)
+        Assert.AreEqual(29, ms.Length);
+    }
+}

--- a/tests/Titanium.Web.Proxy.UnitTests/HttpHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/HttpHelperTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.Helpers;
+using Titanium.Web.Proxy.Http;
+using Titanium.Web.Proxy.Models;
+using Titanium.Web.Proxy.StreamExtended.BufferPool;
+using Titanium.Web.Proxy.StreamExtended.Network;
+
+namespace Titanium.Web.Proxy.UnitTests;
+
+[TestClass]
+public class HttpHelperTests
+{
+    [TestMethod]
+    public void GetEncodingFromContentType_Null_ReturnsDefault()
+    {
+        Assert.AreEqual(HttpHeader.DefaultEncoding, HttpHelper.GetEncodingFromContentType(null));
+    }
+
+    [TestMethod]
+    public void GetEncodingFromContentType_CharsetUtf8_Quoted()
+    {
+        var encoding = HttpHelper.GetEncodingFromContentType("text/html; charset=\"utf-8\"");
+        Assert.AreEqual(Encoding.UTF8.WebName, encoding.WebName);
+    }
+
+    [TestMethod]
+    public void GetEncodingFromContentType_XUserDefined_FallsBackToDefault()
+    {
+        Assert.AreEqual(HttpHeader.DefaultEncoding,
+            HttpHelper.GetEncodingFromContentType("text/plain; charset=x-user-defined"));
+    }
+
+    [TestMethod]
+    public void GetEncodingFromContentType_InvalidCharset_FallsBackToDefault()
+    {
+        Assert.AreEqual(HttpHeader.DefaultEncoding,
+            HttpHelper.GetEncodingFromContentType("text/plain; charset=not-a-real-encoding-zzz"));
+    }
+
+    [TestMethod]
+    public void GetBoundaryFromContentType_QuotedAndUnquoted()
+    {
+        var quoted = HttpHelper.GetBoundaryFromContentType("multipart/form-data; boundary=\"----abc\"");
+        Assert.AreEqual("----abc", quoted.ToString());
+
+        var bare = HttpHelper.GetBoundaryFromContentType("multipart/form-data; boundary=xyz");
+        Assert.AreEqual("xyz", bare.ToString());
+
+        Assert.IsTrue(HttpHelper.GetBoundaryFromContentType(null).IsEmpty);
+    }
+
+    [TestMethod]
+    public void GetWildCardDomainName_Rules()
+    {
+        Assert.AreEqual("127.0.0.1", HttpHelper.GetWildCardDomainName("127.0.0.1", false));
+        Assert.AreEqual("example.com", HttpHelper.GetWildCardDomainName("example.com", false));
+        Assert.AreEqual("*.google.com", HttpHelper.GetWildCardDomainName("www.google.com", false));
+        Assert.AreEqual("pay.vn.ua", HttpHelper.GetWildCardDomainName("pay.vn.ua", false));
+        Assert.AreEqual("foo-bar.example.com", HttpHelper.GetWildCardDomainName("foo-bar.example.com", false));
+        Assert.AreEqual("www.google.com", HttpHelper.GetWildCardDomainName("www.google.com", true));
+    }
+
+    [TestMethod]
+    public async Task GetMethod_RecognizesCommonVerbs()
+    {
+        Assert.AreEqual(KnownMethod.Get, await PeekMethod("GET / HTTP/1.1\r\n"));
+        Assert.AreEqual(KnownMethod.Post, await PeekMethod("POST / HTTP/1.1\r\n"));
+        Assert.AreEqual(KnownMethod.Connect, await PeekMethod("CONNECT host:443 HTTP/1.1\r\n"));
+        Assert.AreEqual(KnownMethod.Pri, await PeekMethod("PRI * HTTP/2.0\r\n"));
+        Assert.AreEqual(KnownMethod.Invalid, await PeekMethod("!!\r\n"));
+    }
+
+    private static async Task<KnownMethod> PeekMethod(string preface)
+    {
+        var pool = new ArrayPoolBufferPool();
+        var reader = new PeekStream(Encoding.ASCII.GetBytes(preface));
+        return await HttpHelper.GetMethod(reader, pool);
+    }
+
+    private sealed class ArrayPoolBufferPool : IBufferPool
+    {
+        public int BufferSize => 8192;
+        public byte[] GetBuffer() => new byte[BufferSize];
+        public byte[] GetBuffer(int bufferSize) => new byte[bufferSize];
+        public void ReturnBuffer(byte[] buffer) { }
+        public void Dispose() { }
+    }
+
+    private sealed class PeekStream : IPeekStream
+    {
+        private readonly byte[] data;
+        public PeekStream(byte[] data) => this.data = data;
+
+        public ValueTask<int> PeekBytesAsync(byte[] buffer, int offset, int index, int count,
+            CancellationToken cancellationToken = default)
+        {
+            if (index >= data.Length) return ValueTask.FromResult(0);
+            var n = Math.Min(count, data.Length - index);
+            Buffer.BlockCopy(data, index, buffer, offset, n);
+            return ValueTask.FromResult(n);
+        }
+
+        public ValueTask<int> PeekByteAsync(int index, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(index < data.Length ? data[index] : -1);
+
+        public byte PeekByteFromBuffer(int index) => data[index];
+    }
+}

--- a/tests/Titanium.Web.Proxy.UnitTests/NetworkHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/NetworkHelperTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.Helpers;
+
+namespace Titanium.Web.Proxy.UnitTests;
+
+[TestClass]
+public class NetworkHelperTests
+{
+    [TestMethod]
+    public void IsLocalIpAddress_LoopbackIp_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkHelper.IsLocalIpAddress(IPAddress.Loopback));
+        Assert.IsTrue(NetworkHelper.IsLocalIpAddress(IPAddress.IPv6Loopback));
+    }
+
+    [TestMethod]
+    public void IsLocalIpAddress_LocalhostName_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkHelper.IsLocalIpAddress("localhost"));
+        Assert.IsTrue(NetworkHelper.IsLocalIpAddress("127.0.0.1"));
+    }
+
+    [TestMethod]
+    public void IsLocalIpAddress_ProxyDnsRequests_SkipsReverseLookupForRemoteHost()
+    {
+        // With proxyDnsRequests=true the helper must not reverse-DNS; a non-local hostname returns false.
+        Assert.IsFalse(NetworkHelper.IsLocalIpAddress("example.com", proxyDnsRequests: true));
+    }
+}

--- a/tests/Titanium.Web.Proxy.UnitTests/ProxyAuthorizationExceptionTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/ProxyAuthorizationExceptionTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.EventArguments;
+using Titanium.Web.Proxy.Exceptions;
+using Titanium.Web.Proxy.Helpers;
+using Titanium.Web.Proxy.Http;
+using Titanium.Web.Proxy.Models;
+using Titanium.Web.Proxy.Network.Tcp;
+
+namespace Titanium.Web.Proxy.UnitTests;
+
+[TestClass]
+public class ProxyAuthorizationExceptionTests
+{
+    [TestMethod]
+    public void Constructor_RedactsAuthorizationHeaders()
+    {
+        using var proxy = new ProxyServer(false, false, false);
+        var endPoint = new ExplicitProxyEndPoint(IPAddress.Loopback, 0, false);
+        using var connection = new QuicClientConnection(
+            proxy, new IPEndPoint(IPAddress.Loopback, 4433), new IPEndPoint(IPAddress.Loopback, 12345));
+        using var cts = new CancellationTokenSource();
+        var clientStream = new HttpClientStream(proxy, connection, System.IO.Stream.Null, proxy.BufferPool, cts.Token);
+        var session = new SessionEventArgs(proxy, endPoint, clientStream, null, cts);
+
+        var headers = new[]
+        {
+            new HttpHeader("Authorization", "Bearer secret-token"),
+            new HttpHeader("Proxy-Authorization", "Basic dXNlcjpwYXNz"),
+            new HttpHeader("Host", "example.com")
+        };
+
+        var ex = new ProxyAuthorizationException("auth failed", session, new Exception("inner"), headers);
+
+        Assert.AreSame(session, ex.Session);
+        var list = ex.Headers.ToList();
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual("[REDACTED]", list[0].Value);
+        Assert.AreEqual("[REDACTED]", list[1].Value);
+        Assert.AreEqual("example.com", list[2].Value);
+    }
+}

--- a/tests/Titanium.Web.Proxy.UnitTests/QpackEncoderDecoderTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/QpackEncoderDecoderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.Http3;
 using Titanium.Web.Proxy.Http3.Qpack;
 
 namespace Titanium.Web.Proxy.UnitTests;
@@ -134,5 +135,41 @@ public class QpackEncoderDecoderTests
         // Longer names use the prefixed-integer overflow form (low 3 bits all 1).
         var longEncoded = QpackEncoder.Encode([("x-custom-header", "my-value-123")]);
         Assert.AreEqual(0x27, longEncoded[2] & 0xFF, "name length >= 7 sets 3-bit prefix to max");
+    }
+
+    [TestMethod]
+    public void Decode_TooShort_ThrowsDecompressionFailed()
+    {
+        var ex = Assert.ThrowsException<Http3ConnectionException>(() => QpackDecoder.Decode(new byte[] { 0x00 }));
+        Assert.AreEqual(Http3ErrorCode.QpackDecompressionFailed, ex.ErrorCode);
+    }
+
+    [TestMethod]
+    public void Decode_NonZeroRicWithoutContext_Throws()
+    {
+        // Prefixed RIC=1 (byte 0x01) + Delta Base=0 (byte 0x00)
+        var ex = Assert.ThrowsException<Http3ConnectionException>(
+            () => QpackDecoder.Decode(new byte[] { 0x01, 0x00 }));
+        Assert.AreEqual(Http3ErrorCode.QpackDecompressionFailed, ex.ErrorCode);
+        StringAssert.Contains(ex.Message, "Required Insert Count");
+    }
+
+    [TestMethod]
+    public void Decode_StaticIndexOutOfRange_Throws()
+    {
+        // RIC=0, DeltaBase=0, then indexed static with absurd index (0xFF with 6-bit prefix overflow)
+        // Static indexed pattern: 11xxxxxx — use index far beyond table via 0xFF 0xFF
+        var ex = Assert.ThrowsException<Http3ConnectionException>(
+            () => QpackDecoder.Decode(new byte[] { 0x00, 0x00, 0xFF, 0xFF }));
+        Assert.AreEqual(Http3ErrorCode.QpackDecompressionFailed, ex.ErrorCode);
+    }
+
+    [TestMethod]
+    public async System.Threading.Tasks.Task DecodeAsync_Cancellation_Throws()
+    {
+        using var cts = new System.Threading.CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsExceptionAsync<System.OperationCanceledException>(
+            () => QpackDecoder.DecodeAsync(new byte[] { 0x00, 0x00 }, null, cts.Token));
     }
 }


### PR DESCRIPTION
## Summary
- Develop new-code coverage is ~79.1% (quality gate fails just under 80%); overall project coverage ~65%
- Add high-ROI unit tests for Http2Helper Send* frame writers, HttpHelper, NetworkHelper, compression factories, CertificateLoader, QPACK decoder errors, ProxyAuthorizationException
- Extend H3 bridge tests for forced-H3 502 and gzip Content-Encoding path

## Test plan
- [x] Unit tests for new coverage clusters
- [x] Http3Bridge integration tests (MsQuic)
- [ ] CI + Sonar develop new_coverage > 80%