### PR TITLE
chore: fix SonarCloud code smells on develop baseline

### DIFF
--- a/src/Titanium.Web.Proxy/Handlers/TransparentClientHandler.cs
+++ b/src/Titanium.Web.Proxy/Handlers/TransparentClientHandler.cs
@@ -590,7 +590,7 @@ public partial class ProxyServer
             // docs promise it for cleartext sessions, not only prior-knowledge h2c.
             if (!isHttps && !endPoint.DecryptSsl && !string.IsNullOrEmpty(endPoint.ForwardHost))
             {
-                var seededHost = endPoint.ForwardHost!;
+                var seededHost = endPoint.ForwardHost;
                 var seededPort = endPoint.ForwardPort ?? port;
                 var httpArgs = new BeforeHttpAuthenticateEventArgs(this, clientConnection, cancellationTokenSource,
                     seededHost, seededPort);
@@ -617,7 +617,7 @@ public partial class ProxyServer
                     }
 
                     var negotiationSession =
-                        new SessionEventArgs(this, endPoint, clientStream!, null, cancellationTokenSource);
+                        new SessionEventArgs(this, endPoint, clientStream, null, cancellationTokenSource);
                     var negotiation = await ResolveHttp2ForClientAsync(negotiationSession,
                         clientOffersHttp2: false, remoteHostName, remotePort, http2ConnectHost, http2ConnectPort,
                         httpArgs.UpstreamHttpProtocol, httpArgs.AllowHttpProtocolTranslation,
@@ -626,7 +626,7 @@ public partial class ProxyServer
 
                     if (negotiation.RequiresH2OriginBridge)
                     {
-                        await SendHttp11ToHttp2Bridge(clientStream!, endPoint, null, null, remoteHostName,
+                        await SendHttp11ToHttp2Bridge(clientStream, endPoint, null, null, remoteHostName,
                             remotePort, http2ConnectHost, http2ConnectPort, negotiation.RetainedConnectionTask,
                             cancellationTokenSource);
                         return;

--- a/src/Titanium.Web.Proxy/Http2/Http2Helper.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2Helper.cs
@@ -45,6 +45,7 @@ namespace Titanium.Web.Proxy.Http2
         public static readonly byte[] ConnectionPreface = Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 
         private static readonly byte[] ConnectMethodBytes = "CONNECT"u8.ToArray();
+        private const string SyntheticResponseFailedMessage = "HTTP/2 synthetic response failed";
 
         /// <summary>
         ///     Connection-level WINDOW_UPDATE increment matching Chrome/Edge (0xEF0001). Grows the peer's
@@ -1363,7 +1364,7 @@ namespace Titanium.Web.Proxy.Http2
                                     if (t.IsFaulted)
                                     {
                                         ReportException(logger, new ProxyHttpException(
-                                            "HTTP/2 synthetic response failed", t.Exception.GetBaseException(),
+                                            SyntheticResponseFailedMessage, t.Exception.GetBaseException(),
                                             sessionArgs));
                                     }
                                 }, TaskScheduler.Default);
@@ -1428,7 +1429,7 @@ namespace Titanium.Web.Proxy.Http2
                                             linkedCts751?.Dispose();
                                             if (t.IsFaulted)
                                                 ReportException(logger, new ProxyHttpException(
-                                                    "HTTP/2 synthetic response failed",
+                                                    SyntheticResponseFailedMessage,
                                                     t.Exception.GetBaseException(), sessionArgs));
                                         }, TaskScheduler.Default);
                                     if (unknProtoState != null) unknProtoState.SyntheticTask = synthTask501;
@@ -1505,7 +1506,7 @@ namespace Titanium.Web.Proxy.Http2
                                         prepareRequestHeaders?.Invoke(request.Headers);
                                         if (wouldInjectVia)
                                         {
-                                            var pseudonym = sessionArgs.Server.ViaHeaderPseudonym!;
+                                            var pseudonym = sessionArgs.Server.ViaHeaderPseudonym;
                                             if (ProxyServer.HasLoopedVia(request.Headers, pseudonym))
                                             {
                                                 sessionArgs.GenericResponse(string.Empty, (HttpStatusCode)508);
@@ -1535,7 +1536,7 @@ namespace Titanium.Web.Proxy.Http2
                                                 if (t.IsFaulted)
                                                 {
                                                     ReportException(logger, new ProxyHttpException(
-                                                        "HTTP/2 synthetic response failed",
+                                                        SyntheticResponseFailedMessage,
                                                         t.Exception.GetBaseException(), sessionArgs));
                                                 }
                                             }, TaskScheduler.Default);
@@ -1679,7 +1680,7 @@ namespace Titanium.Web.Proxy.Http2
                                         if (t.IsFaulted)
                                         {
                                             ReportException(logger, new ProxyHttpException(
-                                                "HTTP/2 synthetic response failed", t.Exception.GetBaseException(),
+                                                SyntheticResponseFailedMessage, t.Exception.GetBaseException(),
                                                 sessionArgs));
                                         }
                                     }, TaskScheduler.Default);

--- a/src/Titanium.Web.Proxy/Http3/Http3RequestStream.cs
+++ b/src/Titanium.Web.Proxy/Http3/Http3RequestStream.cs
@@ -700,7 +700,7 @@ internal static class Http3RequestStream
     ///     True MITM H3→H1: after BeforeRequest left the exchange unchanged, reuse reverse's
     ///     <see cref="Http3OriginBridge.ForwardOverTcpFastAsync"/> instead of full session forward.
     /// </summary>
-    private static bool TryMitmUnchangedH3ToH1Lite(
+    private static bool TryMitmUnchangedH3ToH1Lite( // NOSONAR S107 -- Baseline capture args kept explicit to avoid allocating context structs on the H3 MITM hot path.
         SessionEventArgs sessionArgs,
         BeforeQuicAuthenticateEventArgs authArgs,
         Request request,


### PR DESCRIPTION
## Summary
- Extract HTTP/2 synthetic response failure message constant (S1192)
- Remove redundant null-forgiving operators (S8969)
- Document H3 MITM lite parameter count (S107)

## Test plan
- [x] dotnet build Release
- [ ] SonarCloud QG green