### PR TITLE
feat(mitm): MitmCompressedRelayHelper foundation + RPS Via disable

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/MitmCompressedRelayHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/MitmCompressedRelayHelper.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using Titanium.Web.Proxy.Http;
+
+namespace Titanium.Web.Proxy.Helpers;
+
+/// <summary>
+///     Detects append-only header mutations for MITM compressed HPACK/QPACK relay.
+///     Up to <see cref="DefaultMaxAppendHeaders" /> new unique headers; remove/replace/non-unique edits
+///     fall back to full re-encode.
+/// </summary>
+internal static class MitmCompressedRelayHelper
+{
+    internal const int DefaultMaxAppendHeaders = 4;
+
+    internal readonly struct AddedHeader
+    {
+        internal AddedHeader(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        internal string Name { get; }
+        internal string Value { get; }
+    }
+
+    /// <summary>Stack-friendly buffer for up to four appended header literals.</summary>
+    internal struct AddedHeaderBuffer
+    {
+        private AddedHeader _h0, _h1, _h2, _h3;
+        internal int Count { get; private set; }
+
+        internal void Add(string name, string value)
+        {
+            switch (Count++)
+            {
+                case 0: _h0 = new AddedHeader(name, value); break;
+                case 1: _h1 = new AddedHeader(name, value); break;
+                case 2: _h2 = new AddedHeader(name, value); break;
+                default: _h3 = new AddedHeader(name, value); break;
+            }
+        }
+
+        internal readonly AddedHeader this[int index] => index switch
+        {
+            0 => _h0,
+            1 => _h1,
+            2 => _h2,
+            3 => _h3,
+            _ => throw new ArgumentOutOfRangeException(nameof(index))
+        };
+
+        internal readonly bool ContainsName(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                if (string.Equals(this[i].Name, name, comparison))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>Unique-header snapshot at handler entry for append-only diff.</summary>
+    internal readonly struct HeaderRelayBaseline
+    {
+        private readonly int _mutationCount;
+        private readonly Dictionary<string, string> _unique;
+        private readonly int _nonUniqueNamesAtCapture;
+
+        internal HeaderRelayBaseline(int mutationCount, Dictionary<string, string> unique, int nonUniqueNamesAtCapture)
+        {
+            _mutationCount = mutationCount;
+            _unique = unique;
+            _nonUniqueNamesAtCapture = nonUniqueNamesAtCapture;
+        }
+
+        internal static HeaderRelayBaseline Capture(HeaderCollection headers)
+        {
+            var unique = new Dictionary<string, string>(headers.Headers.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in headers.Headers)
+                unique[kv.Key] = kv.Value.Value;
+            return new HeaderRelayBaseline(headers.MutationCount, unique, headers.NonUniqueHeaders.Count);
+        }
+
+        internal int MutationCount => _mutationCount;
+
+        internal bool AllowsCompressedRelay(HeaderCollection after, int maxAdds, out AddedHeaderBuffer added)
+        {
+            added = default;
+
+            // v1: non-unique header lists (Set-Cookie chains) require full re-encode.
+            if (_nonUniqueNamesAtCapture > 0 || after.NonUniqueHeaders.Count > 0)
+                return after.MutationCount == _mutationCount;
+
+            foreach (var kv in _unique)
+            {
+                if (!after.Headers.TryGetValue(kv.Key, out var header)
+                    || !string.Equals(header.Value, kv.Value, StringComparison.Ordinal))
+                    return false;
+            }
+
+            foreach (var kv in after.Headers)
+            {
+                if (_unique.ContainsKey(kv.Key))
+                    continue;
+
+                if (added.Count >= maxAdds)
+                    return false;
+
+                added.Add(kv.Key, kv.Value.Value);
+            }
+
+            if (added.Count == 0)
+                return after.MutationCount == _mutationCount;
+
+            return added.Count <= maxAdds;
+        }
+    }
+
+    internal static bool AllowsCompressedRelay(
+        HeaderRelayBaseline baseline,
+        HeaderCollection after,
+        int maxAdds,
+        out AddedHeaderBuffer added) =>
+        baseline.AllowsCompressedRelay(after, maxAdds, out added);
+
+    /// <summary>
+    ///     MutationCount-only gate for unchanged headers. When counts diverge, caller must use
+    ///     <see cref="HeaderRelayBaseline"/> snapshot diff.
+    /// </summary>
+    internal static bool AllowsCompressedRelay(
+        int baselineMutationCount,
+        HeaderCollection after,
+        int maxAdds,
+        out AddedHeaderBuffer added)
+    {
+        added = default;
+        return after.MutationCount == baselineMutationCount;
+    }
+}

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmCompressedRelayHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmCompressedRelayHelperTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.Helpers;
+using Titanium.Web.Proxy.Http;
+
+namespace Titanium.Web.Proxy.UnitTests;
+
+[TestClass]
+public class MitmCompressedRelayHelperTests
+{
+    [TestMethod]
+    public void Unchanged_AllowsRelay_WithoutSnapshotDiff()
+    {
+        var headers = new HeaderCollection();
+        headers.AddHeader("accept", "text/html");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(headers);
+
+        Assert.IsTrue(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, headers, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var added));
+        Assert.AreEqual(0, added.Count);
+    }
+
+    [TestMethod]
+    public void AppendOneUniqueHeader_AllowsRelay()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "text/html");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "text/html");
+        after.AddHeader("X-Tracking-Id", "abc");
+
+        Assert.IsTrue(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var added));
+        Assert.AreEqual(1, added.Count);
+        Assert.AreEqual("X-Tracking-Id", added[0].Name);
+        Assert.AreEqual("abc", added[0].Value);
+    }
+
+    [TestMethod]
+    public void AppendTwoUniqueHeaders_AllowsRelay()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+        after.AddHeader("X-A", "1");
+        after.AddHeader("X-B", "2");
+
+        Assert.IsTrue(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var added));
+        Assert.AreEqual(2, added.Count);
+    }
+
+    [TestMethod]
+    public void AppendFiveUniqueHeaders_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+        for (var i = 0; i < 5; i++)
+            after.AddHeader($"X-H{i}", "1");
+
+        Assert.IsFalse(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+    }
+
+    [TestMethod]
+    public void RemoveAndAdd_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+        after.AddHeader("X-New", "1");
+
+        Assert.IsFalse(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+    }
+
+    [TestMethod]
+    public void ReplaceExistingValue_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "text/plain");
+
+        Assert.IsFalse(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+    }
+
+    [TestMethod]
+    public void SecondSetCookie_NonUniqueGrowth_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("cookie", "a=1");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("cookie", "a=1");
+        after.AddHeader("cookie", "b=2");
+
+        Assert.IsFalse(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+    }
+
+    [TestMethod]
+    public void MutationCountOnlyGate_Unchanged_AllowsRelay()
+    {
+        var headers = new HeaderCollection();
+        headers.AddHeader("accept", "*/*");
+        var baselineCount = headers.MutationCount;
+
+        Assert.IsTrue(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baselineCount, headers, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var added));
+        Assert.AreEqual(0, added.Count);
+    }
+
+    [TestMethod]
+    public void MutationCountOnlyGate_Diverged_RequiresSnapshot()
+    {
+        var headers = new HeaderCollection();
+        headers.AddHeader("accept", "*/*");
+        var baselineCount = headers.MutationCount;
+        headers.AddHeader("X-Tracking-Id", "1");
+
+        Assert.IsFalse(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baselineCount, headers, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+    }
+}

--- a/tools/RpsLoadProbe/TwpProxyHost.cs
+++ b/tools/RpsLoadProbe/TwpProxyHost.cs
@@ -772,6 +772,8 @@ internal sealed class TwpProxyHost : IDisposable
         int? maxCachedConnections = null, int? maxConcurrentStreamsPerConnection = null)
     {
         var proxy = new ProxyServer(false, false, false);
+        // Benchmark arms model reverse-style MITM (handler header add only), not explicit-proxy Via.
+        proxy.ViaHeaderPseudonym = string.Empty;
         // Saturation runs must not format or enqueue diagnostics on session threads.
         proxy.Logging.Enabled = false;
         proxy.CertificateManager.SaveFakeCertificates = false;


### PR DESCRIPTION
## Summary
- Add append-only HeaderRelayBaseline diff (max 4 unique headers)
- Unit tests for relay gate cases
- Disable ViaHeaderPseudonym in RPS CreateBaseProxy for benchmark consistency

## Test plan
- [x] MitmCompressedRelayHelperTests (9/9)
- [ ] .NET CI + Sonar