### PR TITLE
feat(mitm): MitmStaticRebuildHelper for drop-only static rebuild (v2 PR1)

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/MitmCompressedRelayHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/MitmCompressedRelayHelper.cs
@@ -11,7 +11,46 @@ namespace Titanium.Web.Proxy.Helpers;
 /// </summary>
 internal static class MitmCompressedRelayHelper
 {
+    /// <summary>Stack-friendly buffer for up to four dropped unique header names.</summary>
+    internal struct DroppedNameBuffer
+    {
+        private string _n0, _n1, _n2, _n3;
+        internal int Count { get; private set; }
+
+        internal void Add(string name)
+        {
+            switch (Count++)
+            {
+                case 0: _n0 = name; break;
+                case 1: _n1 = name; break;
+                case 2: _n2 = name; break;
+                default: _n3 = name; break;
+            }
+        }
+
+        internal readonly string this[int index] => index switch
+        {
+            0 => _n0,
+            1 => _n1,
+            2 => _n2,
+            3 => _n3,
+            _ => throw new ArgumentOutOfRangeException(nameof(index))
+        };
+
+        internal readonly bool Contains(string name, StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                if (string.Equals(this[i], name, comparison))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
     internal const int DefaultMaxAppendHeaders = 4;
+    internal const int DefaultMaxDrops = 4;
 
     internal readonly struct AddedHeader
     {
@@ -117,6 +156,46 @@ internal static class MitmCompressedRelayHelper
                 return after.MutationCount == _mutationCount;
 
             return added.Count <= maxAdds;
+        }
+
+        /// <summary>Detect drop-only mutations (1..maxDrops unique keys removed, no adds/modifies).</summary>
+        internal bool TryDiffDropOnly(HeaderCollection after, int maxDrops, out DroppedNameBuffer dropped)
+        {
+            dropped = default;
+
+            if (_mutationCount == after.MutationCount)
+                return false;
+
+            if (_nonUniqueNamesAtCapture > 0 || after.NonUniqueHeaders.Count > 0)
+                return false;
+
+            var dropCount = 0;
+            foreach (var kv in _unique)
+            {
+                if (after.Headers.TryGetValue(kv.Key, out var header))
+                {
+                    if (!string.Equals(header.Value, kv.Value, StringComparison.Ordinal))
+                        return false;
+                }
+                else
+                {
+                    if (dropCount >= maxDrops)
+                        return false;
+                    dropped.Add(kv.Key);
+                    dropCount++;
+                }
+            }
+
+            if (dropCount == 0)
+                return false;
+
+            foreach (var kv in after.Headers)
+            {
+                if (!_unique.ContainsKey(kv.Key))
+                    return false;
+            }
+
+            return dropCount <= maxDrops;
         }
     }
 

--- a/src/Titanium.Web.Proxy/Helpers/MitmStaticRebuildHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/MitmStaticRebuildHelper.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Titanium.Web.Proxy.Extensions;
+using Titanium.Web.Proxy.Http2.Hpack;
+using Titanium.Web.Proxy.Http3.Qpack;
+using Titanium.Web.Proxy.Models;
+
+namespace Titanium.Web.Proxy.Helpers;
+
+/// <summary>
+///     Drop-only static HPACK/QPACK rebuild for MITM compressed relay (v2).
+///     Re-encodes static-table-only blocks after removing up to four unique headers.
+/// </summary>
+internal static class MitmStaticRebuildHelper
+{
+    internal static bool IsStaticOnlyHpackBlock(ReadOnlySpan<byte> block)
+    {
+        var i = 0;
+        while (i < block.Length)
+        {
+            var b = block[i];
+            if ((b & 0x80) != 0)
+            {
+                if ((b & 0x7f) == 0x7f)
+                    return false;
+                i++;
+                continue;
+            }
+
+            if ((b & 0xe0) == 0x20 || (b & 0xc0) == 0x40)
+                return false;
+
+            if ((b & 0xf0) is 0x00 or 0x10)
+            {
+                if (!TrySkipHpackLiteral(block, ref i))
+                    return false;
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool IsStaticOnlyQpackBlock(ReadOnlySpan<byte> block) =>
+        block.Length >= 2 && block[0] == 0 && block[1] == 0;
+
+    internal static bool TryRebuildStaticHpackBlock(
+        ReadOnlySpan<byte> block,
+        MitmCompressedRelayHelper.DroppedNameBuffer dropped,
+        out byte[] rebuilt)
+    {
+        rebuilt = Array.Empty<byte>();
+        if (block.IsEmpty || dropped.Count == 0)
+            return false;
+        if (!IsStaticOnlyHpackBlock(block))
+            return false;
+
+        var headers = DecodeStaticHpackBlock(block);
+        if (headers == null)
+            return false;
+
+        var filtered = new List<(ByteString Name, ByteString Value)>(headers.Count);
+        foreach (var (name, value) in headers)
+        {
+            if (dropped.Contains(name.GetString()))
+                continue;
+            filtered.Add((name, value));
+        }
+
+        if (filtered.Count == headers.Count)
+            return false;
+
+        rebuilt = EncodeStaticHpackBlock(filtered);
+        return true;
+    }
+
+    internal static bool TryRebuildStaticQpackBlock(
+        ReadOnlySpan<byte> block,
+        MitmCompressedRelayHelper.DroppedNameBuffer dropped,
+        out byte[] rebuilt)
+    {
+        rebuilt = Array.Empty<byte>();
+        if (block.IsEmpty || dropped.Count == 0)
+            return false;
+        if (!IsStaticOnlyQpackBlock(block))
+            return false;
+
+        List<(string Name, string Value)> decoded;
+        try
+        {
+            decoded = QpackDecoder.Decode(block);
+        }
+        catch
+        {
+            return false;
+        }
+
+        var filtered = new List<(string Name, string Value)>(decoded.Count);
+        foreach (var (name, value) in decoded)
+        {
+            if (dropped.Contains(name))
+                continue;
+            filtered.Add((name, value));
+        }
+
+        if (filtered.Count == decoded.Count)
+            return false;
+
+        rebuilt = QpackEncoder.Encode(filtered);
+        return true;
+    }
+
+    private static List<(ByteString Name, ByteString Value)>? DecodeStaticHpackBlock(ReadOnlySpan<byte> block)
+    {
+        var headers = new List<(ByteString, ByteString)>();
+        var decoder = new Decoder(8192, 0);
+        try
+        {
+            decoder.Decode(block, new HeaderCollector((n, v) => headers.Add((n, v))));
+        }
+        catch
+        {
+            return null;
+        }
+
+        return headers;
+    }
+
+    private static byte[] EncodeStaticHpackBlock(List<(ByteString Name, ByteString Value)> headers)
+    {
+        var encoder = new Encoder(0);
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        foreach (var (name, value) in headers)
+            encoder.EncodeHeader(writer, name, value);
+        writer.Flush();
+        return ms.ToArray();
+    }
+
+    private static bool TrySkipHpackLiteral(ReadOnlySpan<byte> block, ref int i)
+    {
+        if (i >= block.Length)
+            return false;
+        var b = block[i];
+        int nameIndex;
+        if ((b & 0xc0) == 0x40)
+        {
+            nameIndex = b & 0x3f;
+            i++;
+            if (nameIndex == 0x3f && !TrySkipHpackIntegerContinuation(block, ref i))
+                return false;
+        }
+        else
+        {
+            nameIndex = b & 0x0f;
+            i++;
+            if (nameIndex == 0x0f && !TrySkipHpackIntegerContinuation(block, ref i))
+                return false;
+        }
+
+        if (nameIndex == 0 && !TrySkipHpackString(block, ref i))
+            return false;
+
+        return TrySkipHpackString(block, ref i);
+    }
+
+    private static bool TrySkipHpackString(ReadOnlySpan<byte> block, ref int i)
+    {
+        if (i >= block.Length)
+            return false;
+        var len = block[i] & 0x7f;
+        i++;
+        if (len == 0x7f)
+        {
+            if (!TrySkipHpackIntegerContinuation(block, ref i, out var extra))
+                return false;
+            len = 127 + extra;
+        }
+
+        if (i + len > block.Length)
+            return false;
+        i += len;
+        return true;
+    }
+
+    private static bool TrySkipHpackIntegerContinuation(ReadOnlySpan<byte> block, ref int i)
+        => TrySkipHpackIntegerContinuation(block, ref i, out _);
+
+    private static bool TrySkipHpackIntegerContinuation(ReadOnlySpan<byte> block, ref int i, out int value)
+    {
+        value = 0;
+        var m = 0;
+        while (i < block.Length)
+        {
+            var b = block[i++];
+            value += (b & 0x7f) << m;
+            if ((b & 0x80) == 0)
+                return true;
+            m += 7;
+            if (m > 28)
+                return false;
+        }
+
+        return false;
+    }
+
+    private sealed class HeaderCollector : IHeaderListener
+    {
+        private readonly Action<ByteString, ByteString> _add;
+
+        internal HeaderCollector(Action<ByteString, ByteString> add) => _add = add;
+
+        public void AddHeader(ByteString name, ByteString value, bool sensitive) => _add(name, value);
+    }
+}

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Titanium.Web.Proxy.Extensions;
+using Titanium.Web.Proxy.Helpers;
+using Titanium.Web.Proxy.Http;
+using Titanium.Web.Proxy.Http2.Hpack;
+using Titanium.Web.Proxy.Http3.Qpack;
+using Titanium.Web.Proxy.Models;
+
+namespace Titanium.Web.Proxy.UnitTests;
+
+[TestClass]
+public class MitmStaticRebuildHelperTests
+{
+    [TestMethod]
+    public void DropOneUniqueHeader_AllowsDropOnlyDiff()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+
+        Assert.IsTrue(baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out var dropped));
+        Assert.AreEqual(1, dropped.Count);
+        Assert.AreEqual("user-agent", dropped[0]);
+    }
+
+    [TestMethod]
+    public void DropTwoUniqueHeaders_AllowsDropOnlyDiff()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        before.AddHeader("referer", "https://example.com");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+
+        Assert.IsTrue(baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out var dropped));
+        Assert.AreEqual(2, dropped.Count);
+    }
+
+    [TestMethod]
+    public void DropFiveUniqueHeaders_Rejected()
+    {
+        var before = new HeaderCollection();
+        for (var i = 0; i < 6; i++)
+            before.AddHeader($"X-H{i}", "v");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("X-H0", "v");
+
+        Assert.IsFalse(baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out _));
+    }
+
+    [TestMethod]
+    public void DropAndAdd_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+        after.AddHeader("X-New", "1");
+
+        Assert.IsFalse(baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out _));
+    }
+
+    [TestMethod]
+    public void ModifyValue_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "text/plain");
+        after.AddHeader("user-agent", "test");
+
+        Assert.IsFalse(baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out _));
+    }
+
+    [TestMethod]
+    public void RebuildStaticHpackBlock_DropOneHeader_MatchesManualEncode()
+    {
+        var original = EncodeStaticHpack(
+            (StaticTable.KnownHeaderMethod, (ByteString)"GET"),
+            ((ByteString)"accept", (ByteString)"*/*"),
+            ((ByteString)"user-agent", (ByteString)"test"));
+
+        Assert.IsTrue(MitmStaticRebuildHelper.IsStaticOnlyHpackBlock(original));
+
+        var dropped = default(MitmCompressedRelayHelper.DroppedNameBuffer);
+        dropped.Add("user-agent");
+        Assert.IsTrue(MitmStaticRebuildHelper.TryRebuildStaticHpackBlock(original, dropped, out var rebuilt));
+
+        var expected = EncodeStaticHpack(
+            (StaticTable.KnownHeaderMethod, (ByteString)"GET"),
+            ((ByteString)"accept", (ByteString)"*/*"));
+
+        Assert.IsTrue(DecodeHpack(expected).SetEquals(DecodeHpack(rebuilt)));
+    }
+
+    [TestMethod]
+    public void RebuildStaticHpackBlock_DropTwoHeaders_RoundTrips()
+    {
+        var original = EncodeStaticHpack(
+            (StaticTable.KnownHeaderMethod, (ByteString)"GET"),
+            ((ByteString)"accept", (ByteString)"*/*"),
+            ((ByteString)"user-agent", (ByteString)"test"),
+            ((ByteString)"referer", (ByteString)"https://example.com"));
+
+        var dropped = default(MitmCompressedRelayHelper.DroppedNameBuffer);
+        dropped.Add("user-agent");
+        dropped.Add("referer");
+        Assert.IsTrue(MitmStaticRebuildHelper.TryRebuildStaticHpackBlock(original, dropped, out var rebuilt));
+
+        var decoded = DecodeHpack(rebuilt);
+        Assert.AreEqual(2, decoded.Count);
+        Assert.IsTrue(decoded.Contains((":method", "GET")));
+        Assert.IsTrue(decoded.Contains(("accept", "*/*")));
+    }
+
+    [TestMethod]
+    public void RebuildStaticQpackBlock_DropOneHeader_RoundTrips()
+    {
+        var original = QpackEncoder.Encode(new[]
+        {
+            (":method", "GET"),
+            ("accept", "*/*"),
+            ("user-agent", "test")
+        });
+
+        Assert.IsTrue(MitmStaticRebuildHelper.IsStaticOnlyQpackBlock(original));
+
+        var dropped = default(MitmCompressedRelayHelper.DroppedNameBuffer);
+        dropped.Add("user-agent");
+        Assert.IsTrue(MitmStaticRebuildHelper.TryRebuildStaticQpackBlock(original, dropped, out var rebuilt));
+
+        var decoded = QpackDecoder.Decode(rebuilt);
+        Assert.AreEqual(2, decoded.Count);
+        Assert.IsTrue(decoded.Exists(h => h.Name == ":method" && h.Value == "GET"));
+        Assert.IsTrue(decoded.Exists(h => h.Name == "accept" && h.Value == "*/*"));
+        Assert.IsFalse(decoded.Exists(h => h.Name == "user-agent"));
+    }
+
+    [TestMethod]
+    public void RebuildStaticHpackBlock_IncrementalIndexingBlock_Rejected()
+    {
+        var encoder = new Encoder(4096);
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        encoder.EncodeHeader(writer, (ByteString)"custom", (ByteString)"value");
+        writer.Flush();
+        var block = ms.ToArray();
+
+        Assert.IsFalse(MitmStaticRebuildHelper.IsStaticOnlyHpackBlock(block));
+
+        var dropped = default(MitmCompressedRelayHelper.DroppedNameBuffer);
+        dropped.Add("custom");
+        Assert.IsFalse(MitmStaticRebuildHelper.TryRebuildStaticHpackBlock(block, dropped, out _));
+    }
+
+    private static byte[] EncodeStaticHpack(params (ByteString Name, ByteString Value)[] headers)
+    {
+        var encoder = new Encoder(0);
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        foreach (var (name, value) in headers)
+            encoder.EncodeHeader(writer, name, value);
+        writer.Flush();
+        return ms.ToArray();
+    }
+
+    private static HashSet<(string Name, string Value)> DecodeHpack(byte[] block)
+    {
+        var result = new HashSet<(string, string)>();
+        var decoder = new Decoder(8192, 0);
+        decoder.Decode(block, new CollectingListener((n, v) =>
+            result.Add((n.GetString(), v.GetString()))));
+        return result;
+    }
+
+    private sealed class CollectingListener : IHeaderListener
+    {
+        private readonly Action<ByteString, ByteString> _add;
+
+        internal CollectingListener(Action<ByteString, ByteString> add) => _add = add;
+
+        public void AddHeader(ByteString name, ByteString value, bool sensitive) => _add(name, value);
+    }
+}


### PR DESCRIPTION
## Summary
- Add MitmStaticRebuildHelper to decode/re-encode static HPACK and QPACK blocks after drop-only mutations
- Extend HeaderRelayBaseline with TryDiffDropOnly (1-4 unique header removes)
- Unit tests for diff cases and rebuild round-trips

## Test plan
- [x] dotnet test --filter MitmStaticRelay/MitmStaticRebuild