### PR TITLE
feat(mitm): wire drop-only H2/H3 relay + non-unique append (v2 PR2)

### DIFF
--- a/src/Titanium.Web.Proxy/Helpers/MitmCompressedRelayHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/MitmCompressedRelayHelper.cs
@@ -107,12 +107,15 @@ internal static class MitmCompressedRelayHelper
     {
         private readonly int _mutationCount;
         private readonly Dictionary<string, string> _unique;
+        private readonly Dictionary<string, List<string>> _nonUniqueSnapshot;
         private readonly int _nonUniqueNamesAtCapture;
 
-        internal HeaderRelayBaseline(int mutationCount, Dictionary<string, string> unique, int nonUniqueNamesAtCapture)
+        internal HeaderRelayBaseline(int mutationCount, Dictionary<string, string> unique,
+            Dictionary<string, List<string>> nonUniqueSnapshot, int nonUniqueNamesAtCapture)
         {
             _mutationCount = mutationCount;
             _unique = unique;
+            _nonUniqueSnapshot = nonUniqueSnapshot;
             _nonUniqueNamesAtCapture = nonUniqueNamesAtCapture;
         }
 
@@ -121,7 +124,18 @@ internal static class MitmCompressedRelayHelper
             var unique = new Dictionary<string, string>(headers.Headers.Count, StringComparer.OrdinalIgnoreCase);
             foreach (var kv in headers.Headers)
                 unique[kv.Key] = kv.Value.Value;
-            return new HeaderRelayBaseline(headers.MutationCount, unique, headers.NonUniqueHeaders.Count);
+
+            var nonUnique = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in headers.NonUniqueHeaders)
+            {
+                var values = new List<string>(kv.Value.Count);
+                foreach (var h in kv.Value)
+                    values.Add(h.Value);
+                nonUnique[kv.Key] = values;
+            }
+
+            return new HeaderRelayBaseline(headers.MutationCount, unique, nonUnique,
+                headers.NonUniqueHeaders.Count);
         }
 
         internal int MutationCount => _mutationCount;
@@ -130,9 +144,8 @@ internal static class MitmCompressedRelayHelper
         {
             added = default;
 
-            // v1: non-unique header lists (Set-Cookie chains) require full re-encode.
             if (_nonUniqueNamesAtCapture > 0 || after.NonUniqueHeaders.Count > 0)
-                return after.MutationCount == _mutationCount;
+                return TryDiffNonUniqueTrailingAppend(after, maxAdds, out added);
 
             foreach (var kv in _unique)
             {
@@ -150,6 +163,80 @@ internal static class MitmCompressedRelayHelper
                     return false;
 
                 added.Add(kv.Key, kv.Value.Value);
+            }
+
+            if (added.Count == 0)
+                return after.MutationCount == _mutationCount;
+
+            return added.Count <= maxAdds;
+        }
+
+        /// <summary>Allow trailing values on existing non-unique header names (e.g. second Set-Cookie).</summary>
+        private bool TryDiffNonUniqueTrailingAppend(HeaderCollection after, int maxAdds, out AddedHeaderBuffer added)
+        {
+            added = default;
+
+            foreach (var kv in _unique)
+            {
+                if (after.NonUniqueHeaders.TryGetValue(kv.Key, out var grownList))
+                {
+                    if (grownList.Count < 1
+                        || !string.Equals(kv.Value, grownList[0].Value, StringComparison.Ordinal))
+                        return false;
+
+                    for (var i = 1; i < grownList.Count; i++)
+                    {
+                        if (added.Count >= maxAdds)
+                            return false;
+                        added.Add(kv.Key, grownList[i].Value);
+                    }
+
+                    continue;
+                }
+
+                if (!after.Headers.TryGetValue(kv.Key, out var header)
+                    || !string.Equals(header.Value, kv.Value, StringComparison.Ordinal))
+                    return false;
+            }
+
+            foreach (var kv in after.Headers)
+            {
+                if (_unique.ContainsKey(kv.Key))
+                    continue;
+
+                if (added.Count >= maxAdds)
+                    return false;
+
+                added.Add(kv.Key, kv.Value.Value);
+            }
+
+            foreach (var kv in _nonUniqueSnapshot)
+            {
+                if (!after.NonUniqueHeaders.TryGetValue(kv.Key, out var afterList))
+                    return false;
+
+                var beforeList = kv.Value;
+                if (afterList.Count < beforeList.Count)
+                    return false;
+
+                for (var i = 0; i < beforeList.Count; i++)
+                {
+                    if (!string.Equals(beforeList[i], afterList[i].Value, StringComparison.Ordinal))
+                        return false;
+                }
+
+                for (var i = beforeList.Count; i < afterList.Count; i++)
+                {
+                    if (added.Count >= maxAdds)
+                        return false;
+                    added.Add(kv.Key, afterList[i].Value);
+                }
+            }
+
+            foreach (var name in after.NonUniqueHeaders.Keys)
+            {
+                if (!_nonUniqueSnapshot.ContainsKey(name) && !_unique.ContainsKey(name))
+                    return false;
             }
 
             if (added.Count == 0)

--- a/src/Titanium.Web.Proxy/Helpers/MitmStaticRebuildHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/MitmStaticRebuildHelper.cs
@@ -135,6 +135,27 @@ internal static class MitmStaticRebuildHelper
         return false;
     }
 
+    internal static bool TryPrepareStaticHpackRelay(
+        byte[] capturedBlock,
+        MitmCompressedRelayHelper.HeaderRelayBaseline baseline,
+        HeaderCollection after,
+        out byte[] blockToRelay,
+        out MitmCompressedRelayHelper.AddedHeaderBuffer appendLiterals)
+    {
+        blockToRelay = capturedBlock;
+        appendLiterals = default;
+
+        if (baseline.TryDiffAppendOnly(after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders,
+                out appendLiterals))
+            return true;
+
+        if (baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out var dropped)
+            && TryRebuildStaticHpackBlock(capturedBlock, dropped, out blockToRelay))
+            return true;
+
+        return false;
+    }
+
     private static List<(ByteString Name, ByteString Value)>? DecodeStaticHpackBlock(ReadOnlySpan<byte> block)
     {
         var headers = new List<(ByteString, ByteString)>();

--- a/src/Titanium.Web.Proxy/Helpers/MitmStaticRebuildHelper.cs
+++ b/src/Titanium.Web.Proxy/Helpers/MitmStaticRebuildHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Titanium.Web.Proxy.Extensions;
+using Titanium.Web.Proxy.Http;
 using Titanium.Web.Proxy.Http2.Hpack;
 using Titanium.Web.Proxy.Http3.Qpack;
 using Titanium.Web.Proxy.Models;
@@ -111,6 +112,27 @@ internal static class MitmStaticRebuildHelper
 
         rebuilt = QpackEncoder.Encode(filtered);
         return true;
+    }
+
+    internal static bool TryPrepareStaticQpackRelay(
+        byte[] capturedBlock,
+        MitmCompressedRelayHelper.HeaderRelayBaseline baseline,
+        HeaderCollection after,
+        out byte[] blockToRelay,
+        out MitmCompressedRelayHelper.AddedHeaderBuffer appendLiterals)
+    {
+        blockToRelay = capturedBlock;
+        appendLiterals = default;
+
+        if (baseline.TryDiffAppendOnly(after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders,
+                out appendLiterals))
+            return true;
+
+        if (baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out var dropped)
+            && TryRebuildStaticQpackBlock(capturedBlock, dropped, out blockToRelay))
+            return true;
+
+        return false;
     }
 
     private static List<(ByteString Name, ByteString Value)>? DecodeStaticHpackBlock(ReadOnlySpan<byte> block)

--- a/src/Titanium.Web.Proxy/Http2/Http2Helper.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2Helper.cs
@@ -4230,29 +4230,17 @@ namespace Titanium.Web.Proxy.Http2
         {
             blockToRelay = capturedBlock;
             appendSuffix = null;
+
+            if (!MitmStaticRebuildHelper.TryPrepareStaticHpackRelay(
+                    capturedBlock, baseline, after, out blockToRelay, out var added))
+                return false;
+
             var injectViaLiteral = injectVia && !after.HeaderExists("via");
-
-            if (baseline.TryDiffAppendOnly(after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders,
-                    out var added))
-            {
-                appendSuffix = BuildStaticLiteralAppendSuffix(
-                    added,
-                    injectViaLiteral && !added.ContainsName("via") ? "via" : null,
-                    injectViaLiteral && !added.ContainsName("via") ? viaValue : null);
-                return true;
-            }
-
-            if (baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out var dropped)
-                && MitmStaticRebuildHelper.TryRebuildStaticHpackBlock(capturedBlock, dropped, out blockToRelay))
-            {
-                appendSuffix = BuildStaticLiteralAppendSuffix(
-                    default,
-                    injectViaLiteral ? "via" : null,
-                    injectViaLiteral ? viaValue : null);
-                return true;
-            }
-
-            return false;
+            appendSuffix = BuildStaticLiteralAppendSuffix(
+                added,
+                injectViaLiteral && !added.ContainsName("via") ? "via" : null,
+                injectViaLiteral && !added.ContainsName("via") ? viaValue : null);
+            return true;
         }
 
         /// <summary>

--- a/src/Titanium.Web.Proxy/Http2/Http2Helper.cs
+++ b/src/Titanium.Web.Proxy/Http2/Http2Helper.cs
@@ -1489,23 +1489,20 @@ namespace Titanium.Web.Proxy.Http2
                                     && relayState.CapturedCompressedHeaders != null
                                     && !request.IsBodyRead
                                     && !request.BodyAvailable
-                                    && MitmCompressedRelayHelper.AllowsCompressedRelay(
+                                    && TryPrepareMitmStaticHpackRelay(
+                                        relayState.CapturedCompressedHeaders,
                                         relayState.HeadersRelayBaseline, request.Headers,
-                                        MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var addedReqHeaders)
+                                        injectVia,
+                                        injectVia
+                                            ? $"{request.HttpVersion.Major}.{request.HttpVersion.Minor} {sessionArgs.Server.ViaHeaderPseudonym}"
+                                            : null,
+                                        out var reqBlockToRelay, out var reqAppendSuffix)
                                     && string.Equals(request.Method, relayState.CapturedMethod, StringComparison.Ordinal)
                                     && request.RequestUriString8.Equals(relayState.CapturedPath)
                                     && request.Authority.Equals(relayState.CapturedAuthority))
                                 {
-                                    var blockToRelay = relayState.CapturedCompressedHeaders;
-                                    var appendSuffix = BuildStaticLiteralAppendSuffix(
-                                        addedReqHeaders,
-                                        injectVia && !addedReqHeaders.ContainsName("via") ? "via" : null,
-                                        injectVia && !addedReqHeaders.ContainsName("via")
-                                            ? $"{request.HttpVersion.Major}.{request.HttpVersion.Minor} {sessionArgs.Server.ViaHeaderPseudonym}"
-                                            : null);
-
-                                    await RelayCompressedHeaderBlockAsync(hbStreamId, blockToRelay, endStreamFlag,
-                                        appendSuffix);
+                                    await RelayCompressedHeaderBlockAsync(hbStreamId, reqBlockToRelay, endStreamFlag,
+                                        reqAppendSuffix);
                                     relayState.EnableRequestDataCompressedRelay();
                                 }
                                 else
@@ -1716,21 +1713,18 @@ namespace Titanium.Web.Proxy.Http2
                                 && connectionState.Streams.TryGetValue(hbStreamId, out var respRelay)
                                 && respRelay.CapturedCompressedHeaders != null
                                 && !finalResponse.IsBodyRead
-                                && MitmCompressedRelayHelper.AllowsCompressedRelay(
+                                && TryPrepareMitmStaticHpackRelay(
+                                    respRelay.CapturedCompressedHeaders,
                                     respRelay.HeadersRelayBaseline, finalResponse.Headers,
-                                    MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var addedRespHeaders)
+                                    injectViaResp,
+                                    injectViaResp
+                                        ? $"{finalResponse.HttpVersion.Major}.{finalResponse.HttpVersion.Minor} {sessionArgs.Server.ViaHeaderPseudonym}"
+                                        : null,
+                                    out var respBlockToRelay, out var respAppendSuffix)
                                 && finalResponse.StatusCode == respRelay.CapturedStatusCode)
                             {
-                                var blockToRelay = respRelay.CapturedCompressedHeaders;
-                                var appendSuffix = BuildStaticLiteralAppendSuffix(
-                                    addedRespHeaders,
-                                    injectViaResp && !addedRespHeaders.ContainsName("via") ? "via" : null,
-                                    injectViaResp && !addedRespHeaders.ContainsName("via")
-                                        ? $"{finalResponse.HttpVersion.Major}.{finalResponse.HttpVersion.Minor} {sessionArgs.Server.ViaHeaderPseudonym}"
-                                        : null);
-
-                                await RelayCompressedHeaderBlockAsync(hbStreamId, blockToRelay, endStreamFlag,
-                                    appendSuffix);
+                                await RelayCompressedHeaderBlockAsync(hbStreamId, respBlockToRelay, endStreamFlag,
+                                    respAppendSuffix);
                                 respRelay.EnableResponseDataCompressedRelay();
                             }
                             else
@@ -4223,6 +4217,42 @@ namespace Titanium.Web.Proxy.Http2
                 WriteStaticLiteralWithoutIndexing(result, offset, extraName, extraValue!);
 
             return result;
+        }
+
+        private static bool TryPrepareMitmStaticHpackRelay(
+            byte[] capturedBlock,
+            MitmCompressedRelayHelper.HeaderRelayBaseline baseline,
+            HeaderCollection after,
+            bool injectVia,
+            string? viaValue,
+            out byte[] blockToRelay,
+            out byte[]? appendSuffix)
+        {
+            blockToRelay = capturedBlock;
+            appendSuffix = null;
+            var injectViaLiteral = injectVia && !after.HeaderExists("via");
+
+            if (baseline.TryDiffAppendOnly(after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders,
+                    out var added))
+            {
+                appendSuffix = BuildStaticLiteralAppendSuffix(
+                    added,
+                    injectViaLiteral && !added.ContainsName("via") ? "via" : null,
+                    injectViaLiteral && !added.ContainsName("via") ? viaValue : null);
+                return true;
+            }
+
+            if (baseline.TryDiffDropOnly(after, MitmCompressedRelayHelper.DefaultMaxDrops, out var dropped)
+                && MitmStaticRebuildHelper.TryRebuildStaticHpackBlock(capturedBlock, dropped, out blockToRelay))
+            {
+                appendSuffix = BuildStaticLiteralAppendSuffix(
+                    default,
+                    injectViaLiteral ? "via" : null,
+                    injectViaLiteral ? viaValue : null);
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Titanium.Web.Proxy/Http3/Http3RequestStream.cs
+++ b/src/Titanium.Web.Proxy/Http3/Http3RequestStream.cs
@@ -361,14 +361,10 @@ internal static class Http3RequestStream
 
                     await onBeforeResponse(sessionArgs);
 
-                    var responseUnchanged = MitmCompressedRelayHelper.AllowsCompressedRelay(
-                                                    respHeaderRelayBaseline, response.Headers,
-                                                    MitmCompressedRelayHelper.DefaultMaxAppendHeaders,
-                                                    out var addedRespHeaders)
-                                            && response.StatusCode == respStatusBaseline
-                                            && response.IsBodyRead == respBodyRead
-                                            && response.BodyAvailable == respBodyAvailable
-                                            && response.StreamBodyWriter == respWriter;
+                    var responseBodyUnchanged = response.StatusCode == respStatusBaseline
+                                                && response.IsBodyRead == respBodyRead
+                                                && response.BodyAvailable == respBodyAvailable
+                                                && response.StreamBodyWriter == respWriter;
 
                     // Match H2 fast-path: skip Via on transparent/SOCKS; append handler/Via literals
                     // onto static QPACK instead of full re-encode when handlers left body unchanged.
@@ -376,20 +372,25 @@ internal static class Http3RequestStream
                                     && !sessionArgs.IsTransparent
                                     && !sessionArgs.IsSocks
                                     && !string.IsNullOrEmpty(server.ViaHeaderPseudonym);
-                    var canRelayPreencoded = responseUnchanged
+                    byte[] qpackHeaders = null!;
+                    MitmCompressedRelayHelper.AddedHeaderBuffer addedRespHeaders = default;
+                    var canRelayPreencoded = responseBodyUnchanged
                                              && fwd.PreencodedQpackHeaders != null
-                                             && IsStaticOnlyQpackBlock(fwd.PreencodedQpackHeaders);
+                                             && IsStaticOnlyQpackBlock(fwd.PreencodedQpackHeaders)
+                                             && MitmStaticRebuildHelper.TryPrepareStaticQpackRelay(
+                                                 fwd.PreencodedQpackHeaders, respHeaderRelayBaseline,
+                                                 response.Headers, out qpackHeaders, out addedRespHeaders);
 
                     if (canRelayPreencoded)
                     {
-                        var qpackHeaders = fwd.PreencodedQpackHeaders!;
                         for (var i = 0; i < addedRespHeaders.Count; i++)
                         {
                             var h = addedRespHeaders[i];
                             qpackHeaders = QpackEncoder.AppendLiteralHeader(qpackHeaders, h.Name, h.Value);
                         }
 
-                        if (injectVia && !addedRespHeaders.ContainsName("via"))
+                        if (injectVia && !addedRespHeaders.ContainsName("via")
+                                       && !response.Headers.HeaderExists("via"))
                         {
                             qpackHeaders = QpackEncoder.AppendLiteralHeader(qpackHeaders, "via",
                                 $"3.0 {server.ViaHeaderPseudonym}");

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmCompressedRelayHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmCompressedRelayHelperTests.cs
@@ -102,7 +102,7 @@ public class MitmCompressedRelayHelperTests
     }
 
     [TestMethod]
-    public void SecondSetCookie_NonUniqueGrowth_Rejected()
+    public void SecondSetCookie_NonUniqueGrowth_AllowedInV2()
     {
         var before = new HeaderCollection();
         before.AddHeader("cookie", "a=1");
@@ -112,8 +112,11 @@ public class MitmCompressedRelayHelperTests
         after.AddHeader("cookie", "a=1");
         after.AddHeader("cookie", "b=2");
 
-        Assert.IsFalse(MitmCompressedRelayHelper.AllowsCompressedRelay(
-            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+        Assert.IsTrue(MitmCompressedRelayHelper.AllowsCompressedRelay(
+            baseline, after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var added));
+        Assert.AreEqual(1, added.Count);
+        Assert.AreEqual("cookie", added[0].Name);
+        Assert.AreEqual("b=2", added[0].Value);
     }
 
     [TestMethod]

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
@@ -155,7 +155,96 @@ public class MitmStaticRebuildHelperTests
     }
 
     [TestMethod]
-    public void RebuildStaticHpackBlock_IncrementalIndexingBlock_Rejected()
+    public void TryPrepareStaticQpackRelay_AppendOnly_ReturnsOriginalBlock()
+    {
+        var original = QpackEncoder.Encode(new[]
+        {
+            (":method", "GET"),
+            ("accept", "*/*")
+        });
+
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+        after.AddHeader("X-Track", "1");
+
+        Assert.IsTrue(MitmStaticRebuildHelper.TryPrepareStaticQpackRelay(
+            original, baseline, after, out var block, out var added));
+        Assert.AreSame(original, block);
+        Assert.AreEqual(1, added.Count);
+    }
+
+    [TestMethod]
+    public void TryPrepareStaticQpackRelay_DropOnly_RebuildsBlock()
+    {
+        var original = QpackEncoder.Encode(new[]
+        {
+            (":method", "GET"),
+            ("accept", "*/*"),
+            ("user-agent", "test")
+        });
+
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+
+        Assert.IsTrue(MitmStaticRebuildHelper.TryPrepareStaticQpackRelay(
+            original, baseline, after, out var block, out var added));
+        Assert.AreNotSame(original, block);
+        Assert.AreEqual(0, added.Count);
+        var decoded = QpackDecoder.Decode(block);
+        Assert.AreEqual(2, decoded.Count);
+        Assert.IsFalse(decoded.Exists(h => h.Name == "user-agent"));
+    }
+
+    [TestMethod]
+    public void NonUniqueSnapshot_TrailingAppend_AllowsRelay()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("set-cookie", "a=1");
+        before.AddHeader("set-cookie", "b=2");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("set-cookie", "a=1");
+        after.AddHeader("set-cookie", "b=2");
+        after.AddHeader("set-cookie", "c=3");
+
+        Assert.IsTrue(baseline.TryDiffAppendOnly(
+            after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out var added));
+        Assert.AreEqual(1, added.Count);
+        Assert.AreEqual("c=3", added[0].Value);
+    }
+
+    [TestMethod]
+    public void RebuildStaticHpackBlock_DropFourHeaders_RoundTrips()
+    {
+        var original = EncodeStaticHpack(
+            (StaticTable.KnownHeaderMethod, (ByteString)"GET"),
+            ((ByteString)"h1", (ByteString)"1"),
+            ((ByteString)"h2", (ByteString)"2"),
+            ((ByteString)"h3", (ByteString)"3"),
+            ((ByteString)"h4", (ByteString)"4"),
+            ((ByteString)"h5", (ByteString)"5"));
+
+        var dropped = default(MitmCompressedRelayHelper.DroppedNameBuffer);
+        dropped.Add("h2");
+        dropped.Add("h4");
+        Assert.IsTrue(MitmStaticRebuildHelper.TryRebuildStaticHpackBlock(original, dropped, out var rebuilt));
+
+        var decoded = DecodeHpack(rebuilt);
+        Assert.AreEqual(4, decoded.Count);
+        Assert.IsFalse(decoded.Contains(("h2", "2")));
+        Assert.IsFalse(decoded.Contains(("h4", "4")));
+    }
+
     {
         var encoder = new Encoder(4096);
         using var ms = new MemoryStream();

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
@@ -287,6 +287,8 @@ public class MitmStaticRebuildHelperTests
             after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
     }
 
+    [TestMethod]
+    public void RebuildStaticHpackBlock_DropFourHeaders_RoundTrips()
     {
         var original = EncodeStaticHpack(
             (StaticTable.KnownHeaderMethod, (ByteString)"GET"),

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
@@ -224,7 +224,69 @@ public class MitmStaticRebuildHelperTests
     }
 
     [TestMethod]
-    public void RebuildStaticHpackBlock_DropFourHeaders_RoundTrips()
+    public void TryPrepareStaticHpackRelay_DropOnly_RebuildsBlock()
+    {
+        var original = EncodeStaticHpack(
+            (StaticTable.KnownHeaderMethod, (ByteString)"GET"),
+            ((ByteString)"accept", (ByteString)"*/*"),
+            ((ByteString)"user-agent", (ByteString)"test"));
+
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        before.AddHeader("user-agent", "test");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "*/*");
+
+        Assert.IsTrue(MitmStaticRebuildHelper.TryPrepareStaticHpackRelay(
+            original, baseline, after, out var block, out var added));
+        Assert.AreNotSame(original, block);
+        Assert.AreEqual(0, added.Count);
+    }
+
+    [TestMethod]
+    public void TryPrepareStaticHpackRelay_ModifyValue_Rejected()
+    {
+        var original = EncodeStaticHpack(
+            (StaticTable.KnownHeaderMethod, (ByteString)"GET"),
+            ((ByteString)"accept", (ByteString)"*/*"));
+
+        var before = new HeaderCollection();
+        before.AddHeader("accept", "*/*");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("accept", "text/plain");
+
+        Assert.IsFalse(MitmStaticRebuildHelper.TryPrepareStaticHpackRelay(
+            original, baseline, after, out _, out _));
+    }
+
+    [TestMethod]
+    public void DropOnly_UnchangedHeaders_ReturnsFalse()
+    {
+        var headers = new HeaderCollection();
+        headers.AddHeader("accept", "*/*");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(headers);
+        Assert.IsFalse(baseline.TryDiffDropOnly(headers, MitmCompressedRelayHelper.DefaultMaxDrops, out _));
+    }
+
+    [TestMethod]
+    public void NonUnique_RemoveFromList_Rejected()
+    {
+        var before = new HeaderCollection();
+        before.AddHeader("set-cookie", "a=1");
+        before.AddHeader("set-cookie", "b=2");
+        var baseline = MitmCompressedRelayHelper.HeaderRelayBaseline.Capture(before);
+
+        var after = new HeaderCollection();
+        after.AddHeader("set-cookie", "a=1");
+
+        Assert.IsFalse(baseline.TryDiffAppendOnly(
+            after, MitmCompressedRelayHelper.DefaultMaxAppendHeaders, out _));
+    }
+
     {
         var original = EncodeStaticHpack(
             (StaticTable.KnownHeaderMethod, (ByteString)"GET"),

--- a/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
+++ b/tests/Titanium.Web.Proxy.UnitTests/MitmStaticRebuildHelperTests.cs
@@ -245,6 +245,8 @@ public class MitmStaticRebuildHelperTests
         Assert.IsFalse(decoded.Contains(("h4", "4")));
     }
 
+    [TestMethod]
+    public void RebuildStaticHpackBlock_IncrementalIndexingBlock_Rejected()
     {
         var encoder = new Encoder(4096);
         using var ms = new MemoryStream();


### PR DESCRIPTION
## Summary
- Wire TryPrepareMitmStaticHpackRelay on H2 request/response compressed relay paths
- Wire TryPrepareStaticQpackRelay on H3 preencoded response path
- Allow trailing non-unique header appends (second Set-Cookie) in baseline diff

## Test plan
- [x] dotnet test --filter Mitm
- [ ] Spot matrix (v1 append arms >= 0.70)