### PR TITLE
prep(7.0.0-beta): docs install links + auto product tag cutter

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -136,13 +136,13 @@ jobs:
         message: Update documentation
         committer_name: GitHub Actions
         committer_email: actions@github.com
-        # Only commit DocFX output ‚Äî never Sonar/coverage/tool install artifacts
+        # Only commit DocFX output ó never Sonar/coverage/tool install artifacts
         add: 'docs'
         # DocFX often races another develop push; rebase instead of failing the job.
         pull: '--rebase --autostash'
 
   # Cross-OS Inspector + Plus dashboard UI gates (Headless / Visual / Playwright).
-  # Inspector unit suite stays on Windows `build` only ó do not re-run it here.
+  # Inspector unit suite stays on Windows `build` only ù do not re-run it here.
   ui-portable:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
@@ -277,9 +277,48 @@ jobs:
         user: ${{ secrets.NUGET_USER }}
 
     - name: Publish Package
-      # MIT packages only ‚Äî never push Titanium.Plus or Titanium.Inspector
+      # MIT packages only ó never push Titanium.Plus or Titanium.Inspector
       run: |
         Get-ChildItem -Recurse -Filter *.nupkg |
           Where-Object { $_.Name -notlike '*Plus*' -and $_.Name -notlike '*Inspector*' -and $_.Name -notlike '*.symbols.nupkg' } |
-          ForEach-Object { dotnet nuget push $_.FullName --source https://api.nuget.org/v3/index.json --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" }
+          ForEach-Object {
+            dotnet nuget push $_.FullName `
+              --source https://api.nuget.org/v3/index.json `
+              --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
+              --skip-duplicate
+          }
+
+  # Product zips stay on release.yml (v* tags). After beta/stable merge, create/move the
+  # version tag and dispatch release.yml (GITHUB_TOKEN tag pushes do not re-trigger workflows).
+  cut-product-tag:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/stable')
+    needs: [build, ui-portable, rps-publish-gate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Create/move product tag and dispatch release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        PREFIX=$(grep -oP '(?<=<VersionPrefix>)[^<]+' src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj | head -n1)
+        if [[ -z "$PREFIX" ]]; then echo "VersionPrefix not found"; exit 1; fi
+        CHANNEL=stable
+        VERSION="$PREFIX"
+        if [[ "${{ github.ref }}" == "refs/heads/beta" ]]; then
+          CHANNEL=beta
+          VERSION="${PREFIX}-beta"
+        fi
+        TAG="v${VERSION}"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git tag -f -a "$TAG" -m "$TAG" "$GITHUB_SHA"
+        git push origin "refs/tags/$TAG" --force
+        echo "Dispatching product release for $TAG (channel=$CHANNEL) at $GITHUB_SHA"
+        gh workflow run release.yml --ref "$GITHUB_REF_NAME" -f channel="$CHANNEL"
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -136,16 +136,18 @@ jobs:
         message: Update documentation
         committer_name: GitHub Actions
         committer_email: actions@github.com
-        # Only commit DocFX output ó never Sonar/coverage/tool install artifacts
+        # Only commit DocFX output -- never Sonar/coverage/tool install artifacts
         add: 'docs'
         # DocFX often races another develop push; rebase instead of failing the job.
         pull: '--rebase --autostash'
 
   # Cross-OS Inspector + Plus dashboard UI gates (Headless / Visual / Playwright).
-  # Inspector unit suite stays on Windows `build` only ù do not re-run it here.
+  # Inspector unit suite stays on Windows `build` only - do not re-run it here.
   ui-portable:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -213,6 +215,8 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/stable')
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v6
     - name: Setup .NET
@@ -277,7 +281,7 @@ jobs:
         user: ${{ secrets.NUGET_USER }}
 
     - name: Publish Package
-      # MIT packages only ó never push Titanium.Plus or Titanium.Inspector
+      # MIT packages only -- never push Titanium.Plus or Titanium.Inspector
       run: |
         Get-ChildItem -Recurse -Filter *.nupkg |
           Where-Object { $_.Name -notlike '*Plus*' -and $_.Name -notlike '*Inspector*' -and $_.Name -notlike '*.symbols.nupkg' } |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,41 @@ on:
         default: 'stable'
 
 jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.v.outputs.tag }}
+      version: ${{ steps.v.outputs.version }}
+      channel: ${{ steps.v.outputs.channel }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: v
+        name: Resolve release tag / channel
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+            VERSION="${TAG#v}"
+            CHANNEL=stable
+            if [[ "$VERSION" == *beta* || "$VERSION" == *-* ]]; then CHANNEL=beta; fi
+          else
+            CHANNEL="${{ github.event.inputs.channel || 'stable' }}"
+            PREFIX=$(grep -oP '(?<=<VersionPrefix>)[^<]+' src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj | head -n1)
+            if [[ -z "$PREFIX" ]]; then echo "VersionPrefix not found"; exit 1; fi
+            if [[ "$CHANNEL" == "beta" ]]; then
+              VERSION="${PREFIX}-beta"
+            else
+              VERSION="$PREFIX"
+            fi
+            TAG="v${VERSION}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$TAG version=$VERSION channel=$CHANNEL"
+
   test:
+    needs: resolve-version
     runs-on: windows-latest
     permissions:
       contents: read
@@ -32,7 +66,7 @@ jobs:
 
 
   build-cli:
-    needs: test
+    needs: [resolve-version, test]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -90,7 +124,7 @@ jobs:
           path: Titanium.Cli-${{ matrix.rid }}.zip
 
   build-plus:
-    needs: test
+    needs: [resolve-version, test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,16 +135,18 @@ jobs:
           dotnet-version: '10.0.x'
           cache: true
       - name: Build Plus
+        env:
+          RELEASE_TAG: ${{ needs.resolve-version.outputs.release_tag }}
         run: |
           dotnet build src/Titanium.Plus/Titanium.Plus.csproj -c Release -o artifacts/plus
-          cp artifacts/plus/Titanium.Plus.dll Titanium.Plus-${{ github.ref_name }}.dll
+          cp artifacts/plus/Titanium.Plus.dll "Titanium.Plus-${RELEASE_TAG}.dll"
       - uses: actions/upload-artifact@v4
         with:
           name: plus
           path: Titanium.Plus-*.dll
 
   build-inspector:
-    needs: test
+    needs: [resolve-version, test]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -168,9 +204,10 @@ jobs:
       - name: Build MSI (WiX)
         if: matrix.msi
         shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
-          $ver = "${{ github.ref_name }}"
-          if ($ver.StartsWith("v")) { $ver = $ver.Substring(1) }
+          $ver = $env:RELEASE_VERSION
           if ($ver -notmatch '^\d+\.\d+\.\d+') { $ver = "7.0.0" }
           $ver = ($ver -split "-")[0]
           ./tools/packaging/build-inspector-msi.ps1 `
@@ -234,29 +271,36 @@ jobs:
             test -e /cli/libmsquic.so -o -e /cli/libmsquic.so.2 -o -e /cli/libmsquic.so.2.5.7
 
   publish-release:
-    needs: [build-cli, build-plus, build-inspector, smoke-http3]
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: [resolve-version, build-cli, build-plus, build-inspector, smoke-http3]
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Build release-manifest and create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.resolve-version.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
+          RELEASE_CHANNEL: ${{ needs.resolve-version.outputs.channel }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          CHANNEL=stable
-          if [[ "$VERSION" == *beta* || "$VERSION" == *-* ]]; then CHANNEL=beta; fi
+          TAG="$RELEASE_TAG"
+          VERSION="$RELEASE_VERSION"
+          CHANNEL="$RELEASE_CHANNEL"
+          export RELEASE_TAG VERSION
           mkdir -p dist
           find artifacts -type f \( -name '*.zip' -o -name '*.dll' -o -name '*.msi' \) -exec cp {} dist/ \;
           python3 - <<'PY'
           import hashlib, json, os, pathlib, datetime
-          version = os.environ["GITHUB_REF_NAME"].lstrip("v")
+          tag = os.environ["RELEASE_TAG"]
+          version = os.environ["VERSION"]
           channel = "beta" if ("-" in version or "beta" in version.lower()) else "stable"
           dist = pathlib.Path("dist")
           def sha(p):
@@ -283,7 +327,7 @@ jobs:
             },
           }
           for name, meta in assets.items():
-            url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/download/{os.environ['GITHUB_REF_NAME']}/{name}"
+            url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/download/{tag}/{name}"
             entry = {"url": url, "sha256": meta["sha256"]}
             if name.startswith("Titanium.Cli-"):
               rid = name.removeprefix("Titanium.Cli-").removesuffix(".zip")
@@ -298,10 +342,19 @@ jobs:
           pathlib.Path("dist/release-manifest.json").write_text(json.dumps(manifest, indent=2))
           print(json.dumps(manifest, indent=2))
           PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f -a "$TAG" -m "$TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$TAG" --force
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --yes --cleanup-tag || true
+            git tag -f -a "$TAG" -m "$TAG" "$GITHUB_SHA"
+            git push origin "refs/tags/$TAG" --force
+          fi
           PRE=""
           if [[ "$CHANNEL" == "beta" ]]; then PRE="--prerelease"; fi
-          gh release create "$GITHUB_REF_NAME" dist/* \
-            --title "$GITHUB_REF_NAME" \
+          gh release create "$TAG" dist/* \
+            --title "$TAG" \
             --generate-notes \
             --target "$GITHUB_SHA" \
             $PRE

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ dotnet add package Titanium.Web.Proxy --prerelease
 
 ### CLI (`titanium` / `twp`)
 
-On Windows, install with winget:
+On Windows, **winget is stable-only**:
 
 ```shell
 winget install justcoding121.TitaniumCli
 ```
 
-Or download self-contained zips from [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when a product release includes `Titanium.Cli-*.zip` assets (NuGet-only tags may not). Extract and run:
+For **beta**, download self-contained zips from [Download](https://titaniumproxy.com/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when a product release includes `Titanium.Cli-*.zip` assets (e.g. `v7.0.0-beta`). Extract and run:
 
 ```shell
 titanium run -c twp.yaml
@@ -78,11 +78,11 @@ titanium update
 
 Each CLI zip also includes a `twp` alias binary.
 
-Optional Plus: run `titanium update --plus`, then enable Plus in config (`plus.enabled: true` with `plus.controlPlane.sharedSecret`). Check with `titanium version --check --plus`.
+Optional Plus: run `titanium update --plus` (add `--channel beta` for prereleases), then enable Plus in config (`plus.enabled: true` with `plus.controlPlane.sharedSecret`). Check with `titanium version --check --plus`.
 
 ### Titanium Inspector
 
-On Windows, winget id `justcoding121.TitaniumInspector`, or MSI / portable zip from [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when those assets are published. Start interception from the Capture menu, install the root CA, then toggle system proxy.
+Prefer [Download](https://titaniumproxy.com/download). On Windows, winget id `justcoding121.TitaniumInspector` is **stable-only**; MSI / portable zip for beta come from the product `v*` release (e.g. `v7.0.0-beta`). Start interception from the Capture menu, install the root CA, then toggle system proxy.
 
 ## Quick start
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -8,8 +8,8 @@ Titanium Web Proxy is a lightweight, high-performance HTTP(S) proxy for general 
 |------|------------|
 | Run a reverse / edge proxy from YAML | [Download CLI](/download) → [CLI](/docs/cli) → [Configuration](/docs/configuration) |
 | Desktop traffic debugging | [Download Inspector](/download) → [Inspector](/docs/inspector) |
-| Ops / control plane | [Plus](/docs/plus) (`titanium update --plus`) |
-| Embed in a .NET app | [Library](/docs/library) + NuGet |
+| Ops / control plane | [Plus](/docs/plus) (`titanium update --plus`; use `--channel beta` for prereleases) |
+| Embed in a .NET app | [Library](/docs/library) + NuGet (`--prerelease` for beta) |
 
 ## CLI reverse in 30 seconds
 
@@ -37,6 +37,8 @@ titanium run -c twp.yaml
 
 ```shell
 dotnet add package Titanium.Web.Proxy
+# beta / prerelease:
+dotnet add package Titanium.Web.Proxy --prerelease
 ```
 
 ```csharp

--- a/website/docs/inspector.md
+++ b/website/docs/inspector.md
@@ -4,12 +4,15 @@ Desktop MITM debugger (Avalonia). Licensed under [PolyForm Noncommercial](https:
 
 ## Install
 
-Windows:
+Prefer the [Download](/download) page (resolves the newest release that has Inspector assets, including prereleases).
 
-- [MSI](https://github.com/justcoding121/titanium-web-proxy/releases/latest/download/TitaniumInspector-win-x64.msi)
-- [Portable zip](https://github.com/justcoding121/titanium-web-proxy/releases/latest/download/TitaniumInspector-win-x64.zip)
+Windows examples for the **7.0 beta** product tag:
+
+- [MSI](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.0-beta/TitaniumInspector-win-x64.msi)
+- [Portable zip](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.0-beta/TitaniumInspector-win-x64.zip)
 
 ```shell
+# Stable community package only — not the 7.0 beta
 winget install justcoding121.TitaniumInspector
 ```
 

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -11,37 +11,39 @@ dotnet add package Titanium.Web.Proxy --prerelease
 
 ## CLI
 
-On Windows:
+On Windows, **winget is stable-only**:
 
 ```shell
 winget install justcoding121.TitaniumCli
 ```
 
-Or take a self-contained zip from [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) / the [Download](/download) page when `Titanium.Cli-*.zip` assets are published.
+For **beta** (or any OS), take a self-contained zip from the [Download](/download) page or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*.zip` assets are published (e.g. `v7.0.0-beta`).
 
 Pick the **matching RID** (e.g. Alpine/K8s → `linux-musl-x64` or `linux-musl-arm64`, not `linux-x64`). HTTP/3 natives ship inside those zips — see [HTTP/3](/docs/http3).
 
 ```shell
-titanium update
-titanium version --check
+titanium update --channel beta
+titanium version --check --channel beta
 titanium http3-deps status
 ```
 
 ## Plus
 
 ```shell
-titanium update --plus
+titanium update --plus --channel beta
 ```
 
 See [Plus](/docs/plus). There is no separate Plus download link.
 
 ## Inspector
 
+Prefer [Download](/download). **winget is stable-only**:
+
 ```shell
 winget install justcoding121.TitaniumInspector
 ```
 
-Or MSI / portable zip from [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) / [Download](/download) when those assets are published. Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
+Or MSI / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when those assets are published (beta example: `v7.0.0-beta`). Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
 
 ## See also
 

--- a/website/docs/library.md
+++ b/website/docs/library.md
@@ -4,6 +4,8 @@ NuGet package **Titanium.Web.Proxy** (MIT). Target framework: **.NET 10**.
 
 ```shell
 dotnet add package Titanium.Web.Proxy
+# Latest prerelease (e.g. 7.0.0-beta):
+dotnet add package Titanium.Web.Proxy --prerelease
 ```
 
 ## Explicit MITM proxy

--- a/website/docs/plus.md
+++ b/website/docs/plus.md
@@ -9,6 +9,9 @@ Plus is distributed as a sidecar DLL next to the CLI. There is **no** public Plu
 ```shell
 titanium update --plus
 titanium version --check --plus
+# Prerelease / beta channel:
+titanium update --plus --channel beta
+titanium version --check --plus --channel beta
 ```
 
 ## Enable

--- a/website/download.md
+++ b/website/download.md
@@ -4,7 +4,9 @@
 import { data as links } from './download.data.ts'
 </script>
 
-Get CLI and Inspector builds from GitHub Releases, or install with winget on Windows.
+Get CLI and Inspector builds from GitHub Releases. Product binaries on this page resolve the newest release that has zip/MSI assets (**including prereleases** such as `v7.0.0-beta`).
+
+**winget** installs the last published **stable** community package only — use the buttons below or GitHub for beta.
 
 HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on Win11 / Server 2022+). Alpine/K8s: use **`linux-musl-*`**, not `linux-x64`. Details: [HTTP/3](/docs/http3).
 
@@ -57,7 +59,7 @@ Self-contained zip. Extract and run. Each zip includes both `titanium` and `twp`
   </div>
 </div>
 
-**winget** (Windows):
+**winget** (Windows, **stable** channel only):
 
 ```shell
 winget install justcoding121.TitaniumCli
@@ -119,7 +121,7 @@ Desktop MITM debugger. Windows: MSI + zip. Linux / macOS: zip only (same RID set
   </div>
 </div>
 
-**winget:**
+**winget** (Windows, **stable** channel only):
 
 ```shell
 winget install justcoding121.TitaniumInspector
@@ -130,9 +132,11 @@ winget install justcoding121.TitaniumInspector
 Plus is **not** a separate download on this page. After the CLI is installed:
 
 ```shell
-titanium update --plus
-titanium version --check --plus
+titanium update --plus --channel beta
+titanium version --check --plus --channel beta
 ```
+
+For stable Plus updates, omit `--channel beta` (default channel is `stable`).
 
 Place the DLL beside the CLI (the updater does this), then enable Plus in config:
 
@@ -164,7 +168,7 @@ dotnet add package Titanium.Web.Proxy --prerelease
 See [Releases](/releases) or [all assets on GitHub](https://github.com/justcoding121/titanium-web-proxy/releases).
 
 ::: tip Product zips vs NuGet tags
-Recent tags such as `6.0.2` may publish only the NuGet package. CLI / Inspector / Plus zip assets are attached when a full product release is cut with the release workflow. Until then, prefer **winget** or the GitHub Releases page for available binaries.
+Some tags publish **NuGet only**. CLI / Inspector / Plus zip assets are attached when a full product release is cut (`v*` tag via the release workflow). After `v7.0.0-beta`, the buttons above should resolve that prerelease’s assets. Prefer this page or GitHub Releases for beta binaries; **winget** remains stable-only.
 :::
 
 ## See also

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -33,10 +33,14 @@ A lightweight, high-performance HTTP(S) proxy — reverse / edge CLI, Inspector,
 
 ## Getting started
 
+Canonical downloads: **[https://titaniumproxy.com/download](https://titaniumproxy.com/download)** · install guide: **[https://titaniumproxy.com/docs/install](https://titaniumproxy.com/docs/install)**.
+
 Install from [NuGet](https://www.nuget.org/packages/Titanium.Web.Proxy):
 
 ```shell
 dotnet add package Titanium.Web.Proxy
+# Beta / prerelease:
+dotnet add package Titanium.Web.Proxy --prerelease
 ```
 
 Start an explicit proxy that logs every requested URL:


### PR DESCRIPTION
## Summary
- Fix website/README/wiki install docs for beta: no /releases/latest traps; --prerelease / --channel beta; winget = stable-only
- NuGet publish --skip-duplicate
- After push to beta/stable: cut-product-tag creates v{VersionPrefix}[-beta] and dispatches release.yml
- release.yml resolves version for workflow_dispatch and publishes under that tag

## Test plan
- [ ] CI green on this PR
- [ ] After merge to develop, open develop→beta release PR
