### PR TITLE
ci(security): explicit workflow GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,10 +26,18 @@ on:
       - '.github/workflows/deploy-website.yml'
       - '.github/dns/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      # SonarCloud / PR decoration when token is present
+      pull-requests: write
+      checks: write
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:

--- a/.github/workflows/pr-path-guard.yml
+++ b/.github/workflows/pr-path-guard.yml
@@ -7,6 +7,10 @@ on:
       - beta
       - stable
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   guard-nc-paths:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,14 @@ on:
         required: true
         default: 'stable'
 
+permissions:
+  contents: read
+
 jobs:
   resolve-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_tag: ${{ steps.v.outputs.tag }}
       version: ${{ steps.v.outputs.version }}

--- a/.github/workflows/rps-saturation.yml
+++ b/.github/workflows/rps-saturation.yml
@@ -119,9 +119,14 @@ on:
         required: true
         default: '3'
 
+permissions:
+  contents: read
+
 jobs:
   rps:
     # PR → beta/stable: compare-spot; push → beta/stable: compare-editions; dispatch: inputs.mode
+    permissions:
+      contents: read
     env:
       RPS_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || (github.event_name == 'pull_request' && 'compare-spot' || 'compare-editions') }}
       RPS_CONCURRENCY: ${{ github.event_name == 'workflow_dispatch' && inputs.concurrency || '8,16,32,64' }}


### PR DESCRIPTION
## Summary
- Fixes **github-advanced-security / CodeQL** review comments on #987 (`actions/missing-workflow-permissions`).
- Adds least-privilege `permissions` on `pr-path-guard`, `release` (incl. `resolve-version`), `rps-saturation`, and `.NET` `build`.

## Notes
- CodeQL check can stay green while AdvSec still leaves PR review comments for these warnings.
- `publish-release` keeps `contents: write` at the job level.

## Test plan
- [ ] CodeQL / AdvSec alerts for these workflows clear or dismiss on re-analysis
- [ ] Existing CI jobs still run (contents: read is sufficient for checkout/build)