### PR TITLE
ci(release): fix setup-dotnet cache failure on product release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+﻿name: release
 
 on:
   push:
@@ -60,7 +60,6 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-          cache: true
       - name: Test
         run: |
           dotnet test src/Titanium.Web.Proxy.sln -c Release --nologo --filter "TestCategory!=Slow&TestCategory!=E2E-UI-Window"
@@ -98,7 +97,6 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-          cache: true
       - uses: actions/cache@v4
         with:
           path: tools/packaging/.cache/http3-natives
@@ -138,7 +136,6 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-          cache: true
       - name: Build Plus
         env:
           RELEASE_TAG: ${{ needs.resolve-version.outputs.release_tag }}
@@ -185,7 +182,6 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-          cache: true
       - uses: actions/cache@v4
         with:
           path: tools/packaging/.cache/http3-natives


### PR DESCRIPTION
## Summary
`release.yml` used `setup-dotnet` `cache: true` without `packages.lock.json`, which fails the job immediately (seen on the `v7.0.0-beta` release attempt).

## Test plan
- [ ] Re-run `release.yml` for `v7.0.0-beta` / `workflow_dispatch` channel=beta after merge
- [ ] Confirm GitHub prerelease assets appear
