### PR TITLE
fix(release): unhang 7.0.1-beta product asset pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
   test:
     needs: resolve-version
     runs-on: windows-latest
+    # Whole-sln `dotnet test` can hang forever on shared Windows runners (integration/TLS);
+    # keep a hard ceiling and match beta push gates (per-project + blame-hang).
+    timeout-minutes: 90
     permissions:
       contents: read
     steps:
@@ -60,13 +63,47 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-      - name: Test
+      - name: Restore and build
         run: |
-          dotnet test src/Titanium.Web.Proxy.sln -c Release --nologo --filter "TestCategory!=Slow&TestCategory!=E2E-UI-Window"
+          dotnet restore src/Titanium.Web.Proxy.sln
+          dotnet build src/Titanium.Web.Proxy.sln -c Release --no-restore
+      - name: Test
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          foreach ($proj in @(
+            'tests/Titanium.Web.Proxy.UnitTests/Titanium.Web.Proxy.UnitTests.csproj',
+            'tests/Titanium.Web.Proxy.Configuration.Tests/Titanium.Web.Proxy.Configuration.Tests.csproj',
+            'tests/Titanium.Plus.Tests/Titanium.Plus.Tests.csproj',
+            'tests/Titanium.Inspector.Tests/Titanium.Inspector.Tests.csproj',
+            'tests/Titanium.Cli.Tests/Titanium.Cli.Tests.csproj'
+          )) {
+            Write-Host "=== $proj ==="
+            dotnet test $proj -c Release --no-build --no-restore --nologo --filter "TestCategory!=Slow&TestCategory!=E2E-UI-Window"
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+          Write-Host "=== E2E / E2E-UI ==="
+          dotnet test tests/Titanium.E2E.Tests/Titanium.E2E.Tests.csproj -c Release --no-build --no-restore --nologo --filter "TestCategory=E2E|TestCategory=E2E-UI"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $maxAttempts = 2
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "=== Integration attempt $attempt of $maxAttempts ==="
+            dotnet test tests/Titanium.Web.Proxy.IntegrationTests/Titanium.Web.Proxy.IntegrationTests.csproj `
+              -c Release --no-build --no-restore --nologo --filter "TestCategory!=Slow" `
+              --blame-hang --blame-hang-timeout 5m
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -eq $maxAttempts) { exit $LASTEXITCODE }
+            Start-Sleep -Seconds 5
+          }
+
           # Product release also requires Headless/Visual/Plus dashboard (same gates as ui-portable).
-          dotnet build tests/Titanium.E2E.Tests/Titanium.E2E.Tests.csproj -c Release
-          pwsh tests/Titanium.E2E.Tests/bin/Release/net10.0/playwright.ps1 install chromium
-          dotnet test tests/Titanium.E2E.Tests/Titanium.E2E.Tests.csproj -c Release --no-build --filter "TestCategory=E2E-UI-Headless|TestCategory=E2E-UI-Visual|TestCategory=E2E-UI-Plus-Dashboard"
+          $pw = Join-Path (Resolve-Path "tests/Titanium.E2E.Tests/bin/Release/net10.0") "playwright.ps1"
+          & $pw install chromium
+          dotnet test tests/Titanium.E2E.Tests/Titanium.E2E.Tests.csproj -c Release --no-build --nologo `
+            --filter "TestCategory=E2E-UI-Headless|TestCategory=E2E-UI-Visual|TestCategory=E2E-UI-Plus-Dashboard"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 
   build-cli:


### PR DESCRIPTION
## Summary
- Release.yml `test` hung indefinitely on whole-sln `dotnet test` (blocked `v7.0.1-beta` GitHub assets after NuGet already published).
- Align release tests with beta push gates: per-project suites, integration `--blame-hang`, Headless/Visual/Plus UI, 90m timeout.

## Test plan
- [ ] PR checks green (build, ui-portable, RPS, Sonar)
- [ ] Merge to beta re-runs cut-product-tag + release.yml
- [ ] Confirm GitHub release `v7.0.1-beta` has CLI/Inspector/Plus zip assets