### PR TITLE
fix(packaging): stop musl Expand-Apk filling the CI disk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,8 @@ jobs:
     strategy:
       fail-fast: false
       # Cap concurrency — many self-contained publishes on shared ubuntu runners run out of disk.
-      max-parallel: 3
+      # Musl + glibc matrix + Inspector/CLI together previously ENOSPCd even at 3.
+      max-parallel: 2
       matrix:
         include:
           - rid: linux-x64
@@ -136,7 +137,9 @@ jobs:
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost /usr/share/swift /usr/local/.ghcup || true
+          sudo docker system prune -af || true
           df -h
       - uses: actions/setup-dotnet@v5
         with:
@@ -145,8 +148,7 @@ jobs:
         with:
           path: tools/packaging/.cache/http3-natives
           key: http3-natives-${{ hashFiles('tools/packaging/http3-native.lock.json') }}-${{ matrix.rid }}
-          restore-keys: |
-            http3-natives-${{ hashFiles('tools/packaging/http3-native.lock.json') }}-
+          # Exact RID only — cross-RID restore-keys previously pulled linux-x64 into musl jobs.
       - name: Publish Cli
         shell: pwsh
         run: |
@@ -198,7 +200,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 2
       matrix:
         include:
           - rid: win-x64
@@ -227,7 +229,9 @@ jobs:
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost /usr/share/swift /usr/local/.ghcup || true
+          sudo docker system prune -af || true
           df -h
       - uses: actions/setup-dotnet@v5
         with:
@@ -236,8 +240,7 @@ jobs:
         with:
           path: tools/packaging/.cache/http3-natives
           key: http3-natives-${{ hashFiles('tools/packaging/http3-native.lock.json') }}-${{ matrix.rid }}
-          restore-keys: |
-            http3-natives-${{ hashFiles('tools/packaging/http3-native.lock.json') }}-
+          # Exact RID only — avoid cross-RID cache pollution (see build-cli).
       - name: Publish Inspector
         shell: pwsh
         run: |

--- a/tools/packaging/bundle-http3-native.ps1
+++ b/tools/packaging/bundle-http3-native.ps1
@@ -157,14 +157,32 @@ function Expand-Deb([string] $debPath, [string] $outDir) {
 
 function Expand-Apk([string] $apkPath, [string] $outDir) {
     New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-    # Alpine .apk = concatenated gzip members (signature tar + data tar).
+    # Alpine .apk = gzip-compressed ustar (optionally concatenated signature + data).
+    # Prefer GNU tar — it handles single- and multi-member apk packages without
+    # writing intermediate part*.tar files (a broken MemoryStream Position loop
+    # previously created tens of thousands of parts and filled the CI disk).
+    Push-Location $outDir
+    try {
+        Invoke-Native "tar" @("-xzf", $apkPath)
+        return
+    }
+    catch {
+        Write-Info "tar -xzf failed for $(Split-Path -Leaf $apkPath); falling back to gzip member walk: $_"
+    }
+    finally { Pop-Location }
+
     $bytes = [System.IO.File]::ReadAllBytes($apkPath)
     $pos = 0
     $part = 0
+    $maxParts = 16
     while ($pos -lt ($bytes.Length - 1) -and $bytes[$pos] -eq 0x1f -and $bytes[$pos + 1] -eq 0x8b) {
-        $remaining = New-Object byte[] ($bytes.Length - $pos)
-        [Array]::Copy($bytes, $pos, $remaining, 0, $remaining.Length)
-        $ms = New-Object System.IO.MemoryStream(,$remaining)
+        if ($part -ge $maxParts) {
+            throw "Expand-Apk refused runaway extract after $maxParts gzip members in $apkPath"
+        }
+        $remainingLen = $bytes.Length - $pos
+        $remaining = New-Object byte[] $remainingLen
+        [Array]::Copy($bytes, $pos, $remaining, 0, $remainingLen)
+        $ms = New-Object System.IO.MemoryStream($remaining, $false)
         $gz = New-Object System.IO.Compression.GzipStream($ms, [System.IO.Compression.CompressionMode]::Decompress)
         $outMs = New-Object System.IO.MemoryStream
         try {
@@ -176,6 +194,9 @@ function Expand-Apk([string] $apkPath, [string] $outDir) {
         $consumed = [int]$ms.Position
         $content = $outMs.ToArray()
         $ms.Dispose(); $outMs.Dispose()
+        if ($consumed -le 0) {
+            throw "Expand-Apk gzip member $part did not advance the stream (apk=$apkPath); refusing ENOSPC loop"
+        }
         $pos += $consumed
 
         $tarPath = Join-Path $outDir ("part{0}.tar" -f $part)
@@ -185,12 +206,11 @@ function Expand-Apk([string] $apkPath, [string] $outDir) {
             & tar -xf (Split-Path -Leaf $tarPath) 2>$null
         }
         finally { Pop-Location }
+        Remove-Item -Force $tarPath -ErrorAction SilentlyContinue
         $part++
     }
     if ($part -eq 0) {
-        Push-Location $outDir
-        try { Invoke-Native "tar" @("-xzf", $apkPath) }
-        finally { Pop-Location }
+        throw "Expand-Apk found no gzip members and tar -xzf failed for $apkPath"
     }
 }
 
@@ -282,23 +302,32 @@ function Bundle-Deb {
 
 function Bundle-Apk {
     $cache = Ensure-CacheDir $Rid
-    $extractRoot = Join-Path $cache "extract"
+    # Extract under TEMP — never under the NuGet/http3 cache — so a bad expand
+    # cannot fill the workspace or poison the Actions cache key.
+    $extractRoot = Join-Path ([IO.Path]::GetTempPath()) ("twp-http3-apk-" + [guid]::NewGuid().ToString("n"))
     if (Test-Path $extractRoot) { Remove-Item -Recurse -Force $extractRoot }
     New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
 
-    foreach ($pkg in $ridEntry.packages) {
-        $leaf = Split-Path -Leaf $pkg.url
-        $dest = Join-Path $cache $leaf
-        Download-Verified $pkg.url $pkg.sha256 $dest
-        $pkgExtract = Join-Path $extractRoot ([IO.Path]::GetFileNameWithoutExtension($leaf))
-        Expand-Apk $dest $pkgExtract
-    }
+    try {
+        foreach ($pkg in $ridEntry.packages) {
+            $leaf = Split-Path -Leaf $pkg.url
+            $dest = Join-Path $cache $leaf
+            Download-Verified $pkg.url $pkg.sha256 $dest
+            $pkgExtract = Join-Path $extractRoot ([IO.Path]::GetFileNameWithoutExtension($leaf))
+            Expand-Apk $dest $pkgExtract
+        }
 
-    $copied = Copy-SharedLibs $extractRoot $PublishDir
-    Write-Info "copied: $($copied -join ', ')"
-    Ensure-SonameLinks $PublishDir
-    Set-LinuxRpath $PublishDir
-    Assert-RequiredFiles @("libmsquic.so*", "libssl.so.3", "libcrypto.so.3")
+        $copied = Copy-SharedLibs $extractRoot $PublishDir
+        Write-Info "copied: $($copied -join ', ')"
+        Ensure-SonameLinks $PublishDir
+        Set-LinuxRpath $PublishDir
+        Assert-RequiredFiles @("libmsquic.so*", "libssl.so.3", "libcrypto.so.3")
+    }
+    finally {
+        if (Test-Path $extractRoot) {
+            Remove-Item -Recurse -Force $extractRoot -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Resolve-BrewPrefix {


### PR DESCRIPTION
## Summary
- Fix musl HTTP/3 apk expand that filled the runner disk (`part35686.tar` / ENOSPC) during develop `release.yml` packaging gate
- Prefer `tar -xzf` for Alpine apks; hard-cap gzip-member fallback; extract under TEMP
- release.yml: `max-parallel: 2`, more disk free, no cross-RID http3 cache restore

## Test plan
- [ ] Merge to develop
- [ ] Re-dispatch `release.yml` on develop `channel=beta`
- [ ] Confirm linux-musl-x64/arm64 CLI + Inspector publish succeed