### PR TITLE
fix(website): dual stable/beta downloads + always redeploy on beta/stable

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -76,6 +76,29 @@ jobs:
             echo "Warning: docs/api missing; API pages will not be published"
           fi
 
+      # GitHub Pages + VitePress cleanUrls: /download sometimes keeps a stale
+      # object while /download.html updates. Publish both shapes so the nav link works.
+      - name: Mirror cleanUrls HTML as index.html
+        shell: bash
+        run: |
+          set -euo pipefail
+          dist=website/.vitepress/dist
+          for f in "$dist"/*.html; do
+            base="$(basename "$f" .html)"
+            [[ "$base" == "index" || "$base" == "404" ]] && continue
+            mkdir -p "$dist/$base"
+            cp -f "$f" "$dist/$base/index.html"
+          done
+          # Nested docs pages
+          if [ -d "$dist/docs" ]; then
+            find "$dist/docs" -name '*.html' ! -name 'index.html' ! -name '404.html' | while read -r f; do
+              base="$(basename "$f" .html)"
+              dir="$(dirname "$f")"
+              mkdir -p "$dir/$base"
+              cp -f "$f" "$dir/$base/index.html"
+            done
+          fi
+
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,16 +1,13 @@
 name: Deploy website
 
 on:
+  # Always on product-channel and develop pushes so download.data.ts rebuilds when
+  # beta/stable merges land (those merges often do not touch website/**).
   push:
     branches:
       - develop
-    paths:
-      - 'website/**'
-      - 'wiki/images/**'
-      - 'docs/api/**'
-      - 'docs/styles/**'
-      - 'docs/fonts/**'
-      - '.github/workflows/deploy-website.yml'
+      - beta
+      - stable
   pull_request:
     branches:
       - develop
@@ -21,6 +18,8 @@ on:
       - 'docs/styles/**'
       - 'docs/fonts/**'
       - '.github/workflows/deploy-website.yml'
+  # Human-published releases. Actions GITHUB_TOKEN `gh release create` does not
+  # cascade this event — release.yml also dispatches this workflow after assets.
   release:
     types: [published]
   workflow_dispatch:
@@ -84,7 +83,14 @@ jobs:
           path: website/.vitepress/dist
 
   deploy:
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/develop' || github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+    if: >
+      github.event_name != 'pull_request' && (
+        github.ref == 'refs/heads/develop' ||
+        github.ref == 'refs/heads/beta' ||
+        github.ref == 'refs/heads/stable' ||
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_dispatch'
+      )
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -444,3 +445,19 @@ jobs:
             fi
             rm -f "$NOTES_FILE"
           fi
+
+      - name: Refresh website download links
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_CHANNEL: ${{ needs.resolve-version.outputs.channel }}
+        run: |
+          set -euo pipefail
+          # GITHUB_TOKEN `gh release create` does not fire `release: published` for
+          # other workflows. Rebuild Pages so download.data.ts sees new zip/MSI assets.
+          REF=develop
+          case "$RELEASE_CHANNEL" in
+            beta) REF=beta ;;
+            stable) REF=stable ;;
+          esac
+          echo "Dispatching deploy-website.yml --ref $REF (channel=$RELEASE_CHANNEL)"
+          gh workflow run deploy-website.yml --ref "$REF"

--- a/website/download.data.ts
+++ b/website/download.data.ts
@@ -47,15 +47,6 @@ type GhRelease = {
   assets: Array<{ name: string; browser_download_url: string }>
 }
 
-function emptyLinks(): DownloadLinks {
-  return {
-    cli: {},
-    inspector: {},
-    releasesUrl: RELEASES,
-    latestTag: null,
-  }
-}
-
 function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json',
@@ -94,15 +85,29 @@ function mapReleases(releases: GhRelease[]): DownloadLinks {
 
 export default defineLoader({
   async load(): Promise<DownloadLinks> {
+    const url =
+      'https://api.github.com/repos/justcoding121/titanium-web-proxy/releases?per_page=40'
     try {
-      const res = await fetch(
-        'https://api.github.com/repos/justcoding121/titanium-web-proxy/releases?per_page=40',
-        { headers: githubHeaders() },
-      )
-      if (!res.ok) return emptyLinks()
-      return mapReleases((await res.json()) as GhRelease[])
-    } catch {
-      return emptyLinks()
+      const res = await fetch(url, { headers: githubHeaders() })
+      if (!res.ok) {
+        throw new Error(`GitHub releases API ${res.status} ${res.statusText}`)
+      }
+      const links = mapReleases((await res.json()) as GhRelease[])
+      const cliCount = Object.keys(links.cli).length
+      if (cliCount === 0) {
+        console.warn(
+          '[download.data] GitHub releases returned no CLI zip assets — download buttons will be empty',
+        )
+      } else {
+        console.log(
+          `[download.data] resolved ${cliCount} CLI RIDs from tag ${links.cli['win-x64']?.tag ?? links.latestTag}`,
+        )
+      }
+      return links
+    } catch (e) {
+      console.error('[download.data] failed to load GitHub releases:', e)
+      // Fail the Pages build rather than silently shipping empty download buttons.
+      throw e
     }
   },
 })

--- a/website/download.data.ts
+++ b/website/download.data.ts
@@ -16,14 +16,20 @@ export interface DownloadAsset {
   tag: string
 }
 
-export interface DownloadLinks {
+export interface ChannelDownloads {
+  /** GitHub release tag, or null when no product zip/MSI release exists for the channel. */
+  tag: string | null
   cli: Partial<Record<CliRid, DownloadAsset>>
   inspector: {
     msi?: DownloadAsset
     zip?: DownloadAsset
   } & Partial<Record<CliRid, DownloadAsset>>
+}
+
+export interface DownloadLinks {
+  stable: ChannelDownloads
+  beta: ChannelDownloads
   releasesUrl: string
-  latestTag: string | null
 }
 
 declare const data: DownloadLinks
@@ -47,6 +53,10 @@ type GhRelease = {
   assets: Array<{ name: string; browser_download_url: string }>
 }
 
+function emptyChannel(): ChannelDownloads {
+  return { tag: null, cli: {}, inspector: {} }
+}
+
 function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json',
@@ -58,7 +68,28 @@ function githubHeaders(): Record<string, string> {
   return headers
 }
 
-function assignAsset(out: DownloadLinks, asset: DownloadAsset, name: string): void {
+function hasProductAssets(r: GhRelease): boolean {
+  return (r.assets ?? []).some(
+    (a) =>
+      a.name.startsWith('Titanium.Cli-') ||
+      a.name.startsWith('TitaniumInspector-') ||
+      a.name.startsWith('Titanium.Plus-'),
+  )
+}
+
+function isStableRelease(r: GhRelease): boolean {
+  return !r.prerelease && !r.tag_name.includes('-')
+}
+
+function isBetaRelease(r: GhRelease): boolean {
+  return (
+    r.prerelease ||
+    r.tag_name.includes('beta') ||
+    /-/.test(r.tag_name.replace(/^v/, ''))
+  )
+}
+
+function assignAsset(out: ChannelDownloads, asset: DownloadAsset, name: string): void {
   for (const rid of CLI_RIDS) {
     if (name === `Titanium.Cli-${rid}.zip` && !out.cli[rid]) out.cli[rid] = asset
     if (name === `TitaniumInspector-${rid}.zip` && !out.inspector[rid]) out.inspector[rid] = asset
@@ -67,47 +98,55 @@ function assignAsset(out: DownloadLinks, asset: DownloadAsset, name: string): vo
   if (name === 'TitaniumInspector-win-x64.zip' && !out.inspector.zip) out.inspector.zip = asset
 }
 
-function mapReleases(releases: GhRelease[]): DownloadLinks {
-  const out: DownloadLinks = {
-    cli: {},
-    inspector: {},
-    releasesUrl: RELEASES,
-    latestTag: releases.find((r) => !r.prerelease)?.tag_name ?? null,
-  }
-
-  for (const r of releases) {
-    for (const a of r.assets ?? []) {
-      assignAsset(out, { name: a.name, url: a.browser_download_url, tag: r.tag_name }, a.name)
-    }
+function channelFromRelease(r: GhRelease): ChannelDownloads {
+  const out = emptyChannel()
+  out.tag = r.tag_name
+  for (const a of r.assets ?? []) {
+    assignAsset(
+      out,
+      { name: a.name, url: a.browser_download_url, tag: r.tag_name },
+      a.name,
+    )
   }
   return out
+}
+
+function pickChannel(
+  releases: GhRelease[],
+  pred: (r: GhRelease) => boolean,
+): ChannelDownloads {
+  const hit = releases.find((r) => pred(r) && hasProductAssets(r))
+  return hit ? channelFromRelease(hit) : emptyChannel()
+}
+
+function mapReleases(releases: GhRelease[]): DownloadLinks {
+  return {
+    stable: pickChannel(releases, isStableRelease),
+    beta: pickChannel(releases, isBetaRelease),
+    releasesUrl: RELEASES,
+  }
 }
 
 export default defineLoader({
   async load(): Promise<DownloadLinks> {
     const url =
       'https://api.github.com/repos/justcoding121/titanium-web-proxy/releases?per_page=40'
-    try {
-      const res = await fetch(url, { headers: githubHeaders() })
-      if (!res.ok) {
-        throw new Error(`GitHub releases API ${res.status} ${res.statusText}`)
-      }
-      const links = mapReleases((await res.json()) as GhRelease[])
-      const cliCount = Object.keys(links.cli).length
-      if (cliCount === 0) {
-        console.warn(
-          '[download.data] GitHub releases returned no CLI zip assets — download buttons will be empty',
-        )
-      } else {
-        console.log(
-          `[download.data] resolved ${cliCount} CLI RIDs from tag ${links.cli['win-x64']?.tag ?? links.latestTag}`,
-        )
-      }
-      return links
-    } catch (e) {
-      console.error('[download.data] failed to load GitHub releases:', e)
-      // Fail the Pages build rather than silently shipping empty download buttons.
-      throw e
+    const res = await fetch(url, { headers: githubHeaders() })
+    if (!res.ok) {
+      throw new Error(`GitHub releases API ${res.status} ${res.statusText}`)
     }
+    const links = mapReleases((await res.json()) as GhRelease[])
+    const stableCli = Object.keys(links.stable.cli).length
+    const betaCli = Object.keys(links.beta.cli).length
+    console.log(
+      `[download.data] stable=${links.stable.tag ?? 'none'} (${stableCli} CLI) ` +
+        `beta=${links.beta.tag ?? 'none'} (${betaCli} CLI)`,
+    )
+    if (stableCli === 0 && betaCli === 0) {
+      throw new Error(
+        '[download.data] no CLI/Inspector zip assets found on any GitHub Release',
+      )
+    }
+    return links
   },
 })

--- a/website/download.md
+++ b/website/download.md
@@ -2,67 +2,118 @@
 
 <script setup>
 import { data as links } from './download.data.ts'
+
+const channels = [
+  { id: 'stable', label: 'Stable', hint: 'Recommended for production', data: links.stable },
+  { id: 'beta', label: 'Beta', hint: 'Prerelease — newest features', data: links.beta },
+]
 </script>
 
-Get CLI and Inspector builds from GitHub Releases. Product binaries on this page resolve the newest release that has zip/MSI assets (**including prereleases** such as `v7.0.2-beta`).
+Get CLI and Inspector builds from GitHub Releases. This page lists the **latest stable** and **latest beta** product releases that include zip/MSI assets (NuGet-only tags are skipped).
 
 **winget** installs the last published **stable** community package only — use the buttons below or GitHub for beta.
 
 HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on Win11 / Server 2022+). Alpine/K8s: use **`linux-musl-*`**, not `linux-x64`. Details: [HTTP/3](/docs/http3).
 
-## CLI (`titanium` / `twp`) {#cli}
+<div v-for="ch in channels" :key="ch.id" class="download-channel">
+  <h2 :id="ch.id">
+    {{ ch.label }}
+    <span v-if="ch.data.tag" class="badge-pre">{{ ch.data.tag }}</span>
+  </h2>
+  <p class="vp-muted">
+    {{ ch.hint }}
+    <template v-if="!ch.data.tag">
+      — no product zip/MSI release on this channel yet; see
+      <a :href="links.releasesUrl">GitHub Releases</a>.
+    </template>
+  </p>
 
-Self-contained zip. Extract and run. Each zip includes both `titanium` and `twp` binaries.
+  <h3 :id="ch.id + '-cli'">CLI (<code>titanium</code> / <code>twp</code>)</h3>
+  <p>Self-contained zip. Extract and run. Each zip includes both <code>titanium</code> and <code>twp</code> binaries.</p>
+  <div class="download-grid">
+    <div class="download-row">
+      <strong>Windows x64</strong>
+      <a v-if="ch.data.cli['win-x64']" :href="ch.data.cli['win-x64'].url">{{ ch.data.cli['win-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux x64 (glibc)</strong>
+      <a v-if="ch.data.cli['linux-x64']" :href="ch.data.cli['linux-x64'].url">{{ ch.data.cli['linux-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 (glibc)</strong>
+      <a v-if="ch.data.cli['linux-arm64']" :href="ch.data.cli['linux-arm64'].url">{{ ch.data.cli['linux-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Alpine / musl x64</strong>
+      <a v-if="ch.data.cli['linux-musl-x64']" :href="ch.data.cli['linux-musl-x64'].url">{{ ch.data.cli['linux-musl-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Alpine / musl arm64</strong>
+      <a v-if="ch.data.cli['linux-musl-arm64']" :href="ch.data.cli['linux-musl-arm64'].url">{{ ch.data.cli['linux-musl-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>macOS x64</strong>
+      <a v-if="ch.data.cli['osx-x64']" :href="ch.data.cli['osx-x64'].url">{{ ch.data.cli['osx-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>macOS arm64</strong>
+      <a v-if="ch.data.cli['osx-arm64']" :href="ch.data.cli['osx-arm64'].url">{{ ch.data.cli['osx-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+  </div>
 
-<div class="download-grid">
-  <div class="download-row">
-    <strong>Windows x64</strong>
-    <a v-if="links.cli['win-x64']" :href="links.cli['win-x64'].url">{{ links.cli['win-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — use winget or <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['win-x64']" class="badge-pre">{{ links.cli['win-x64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Linux x64 (glibc)</strong>
-    <a v-if="links.cli['linux-x64']" :href="links.cli['linux-x64'].url">{{ links.cli['linux-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['linux-x64']" class="badge-pre">{{ links.cli['linux-x64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Linux arm64 (glibc)</strong>
-    <a v-if="links.cli['linux-arm64']" :href="links.cli['linux-arm64'].url">{{ links.cli['linux-arm64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['linux-arm64']" class="badge-pre">{{ links.cli['linux-arm64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Alpine / musl x64</strong>
-    <a v-if="links.cli['linux-musl-x64']" :href="links.cli['linux-musl-x64'].url">{{ links.cli['linux-musl-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['linux-musl-x64']" class="badge-pre">{{ links.cli['linux-musl-x64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Alpine / musl arm64</strong>
-    <a v-if="links.cli['linux-musl-arm64']" :href="links.cli['linux-musl-arm64'].url">{{ links.cli['linux-musl-arm64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['linux-musl-arm64']" class="badge-pre">{{ links.cli['linux-musl-arm64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>macOS x64</strong>
-    <a v-if="links.cli['osx-x64']" :href="links.cli['osx-x64'].url">{{ links.cli['osx-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['osx-x64']" class="badge-pre">{{ links.cli['osx-x64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>macOS arm64</strong>
-    <a v-if="links.cli['osx-arm64']" :href="links.cli['osx-arm64'].url">{{ links.cli['osx-arm64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.cli['osx-arm64']" class="badge-pre">{{ links.cli['osx-arm64'].tag }}</span>
+  <h3 :id="ch.id + '-inspector'">Titanium Inspector</h3>
+  <p>Desktop MITM debugger. Windows: MSI + zip. Linux / macOS: zip only (same RID set as CLI).</p>
+  <div class="download-grid">
+    <div class="download-row">
+      <strong>Windows MSI</strong>
+      <a v-if="ch.data.inspector.msi" :href="ch.data.inspector.msi.url">{{ ch.data.inspector.msi.name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Windows zip</strong>
+      <a v-if="ch.data.inspector.zip || ch.data.inspector['win-x64']" :href="(ch.data.inspector.zip || ch.data.inspector['win-x64']).url">{{ (ch.data.inspector.zip || ch.data.inspector['win-x64']).name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux x64</strong>
+      <a v-if="ch.data.inspector['linux-x64']" :href="ch.data.inspector['linux-x64'].url">{{ ch.data.inspector['linux-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64</strong>
+      <a v-if="ch.data.inspector['linux-arm64']" :href="ch.data.inspector['linux-arm64'].url">{{ ch.data.inspector['linux-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Alpine / musl x64</strong>
+      <a v-if="ch.data.inspector['linux-musl-x64']" :href="ch.data.inspector['linux-musl-x64'].url">{{ ch.data.inspector['linux-musl-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>macOS arm64</strong>
+      <a v-if="ch.data.inspector['osx-arm64']" :href="ch.data.inspector['osx-arm64'].url">{{ ch.data.inspector['osx-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>macOS x64</strong>
+      <a v-if="ch.data.inspector['osx-x64']" :href="ch.data.inspector['osx-x64'].url">{{ ch.data.inspector['osx-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
   </div>
 </div>
 
-**winget** (Windows, **stable** channel only):
+## winget (Windows, stable only)
 
 ```shell
 winget install justcoding121.TitaniumCli
+winget install justcoding121.TitaniumInspector
 ```
 
 ```shell
@@ -70,61 +121,6 @@ titanium run -c twp.yaml
 titanium version --check
 titanium update
 titanium http3-deps status
-```
-
-## Titanium Inspector {#inspector}
-
-Desktop MITM debugger. Windows: MSI + zip. Linux / macOS: zip only (same RID set as CLI).
-
-<div class="download-grid">
-  <div class="download-row">
-    <strong>Windows MSI</strong>
-    <a v-if="links.inspector.msi" :href="links.inspector.msi.url">{{ links.inspector.msi.name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — use winget or <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector.msi" class="badge-pre">{{ links.inspector.msi.tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Windows zip</strong>
-    <a v-if="links.inspector.zip || links.inspector['win-x64']" :href="(links.inspector.zip || links.inspector['win-x64']).url">{{ (links.inspector.zip || links.inspector['win-x64']).name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector.zip || links.inspector['win-x64']" class="badge-pre">{{ (links.inspector.zip || links.inspector['win-x64']).tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Linux x64</strong>
-    <a v-if="links.inspector['linux-x64']" :href="links.inspector['linux-x64'].url">{{ links.inspector['linux-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector['linux-x64']" class="badge-pre">{{ links.inspector['linux-x64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Linux arm64</strong>
-    <a v-if="links.inspector['linux-arm64']" :href="links.inspector['linux-arm64'].url">{{ links.inspector['linux-arm64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector['linux-arm64']" class="badge-pre">{{ links.inspector['linux-arm64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>Alpine / musl x64</strong>
-    <a v-if="links.inspector['linux-musl-x64']" :href="links.inspector['linux-musl-x64'].url">{{ links.inspector['linux-musl-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector['linux-musl-x64']" class="badge-pre">{{ links.inspector['linux-musl-x64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>macOS arm64</strong>
-    <a v-if="links.inspector['osx-arm64']" :href="links.inspector['osx-arm64'].url">{{ links.inspector['osx-arm64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector['osx-arm64']" class="badge-pre">{{ links.inspector['osx-arm64'].tag }}</span>
-  </div>
-  <div class="download-row">
-    <strong>macOS x64</strong>
-    <a v-if="links.inspector['osx-x64']" :href="links.inspector['osx-x64'].url">{{ links.inspector['osx-x64'].name }}</a>
-    <span v-else class="vp-muted">Not in current releases yet — see <a :href="links.releasesUrl">GitHub Releases</a></span>
-    <span v-if="links.inspector['osx-x64']" class="badge-pre">{{ links.inspector['osx-x64'].tag }}</span>
-  </div>
-</div>
-
-**winget** (Windows, **stable** channel only):
-
-```shell
-winget install justcoding121.TitaniumInspector
 ```
 
 ## Titanium.Plus
@@ -168,7 +164,7 @@ dotnet add package Titanium.Web.Proxy --prerelease
 See [Releases](/releases) or [all assets on GitHub](https://github.com/justcoding121/titanium-web-proxy/releases).
 
 ::: tip Product zips vs NuGet tags
-Some tags publish **NuGet only**. CLI / Inspector / Plus zip assets are attached when a full product release is cut (`v*` tag via the release workflow). After `v7.0.2-beta`, the buttons above should resolve that prerelease’s assets. Prefer this page or GitHub Releases for beta binaries; **winget** remains stable-only.
+Some tags publish **NuGet only**. CLI / Inspector zip assets appear above only when a full product release is cut (`v*` tag via the release workflow). Prefer this page or GitHub Releases for binaries; **winget** remains stable-only.
 :::
 
 ## See also


### PR DESCRIPTION
## Summary
- Download page lists **latest stable** and **latest beta** product zip/MSI releases separately
- Deploy website always on push to `develop` / `beta` / `stable`
- After `release.yml` publishes assets, explicitly dispatch Deploy website (GITHUB_TOKEN does not cascade `release: published`)
- Mirror `*.html` as `dir/index.html` so GitHub Pages `/download` is not stuck on a stale object

## Test plan
- [x] Local `npm run docs:build`: beta=v7.0.2-beta with CLI/MSI links; stable shows not-published until next stable product cut
- [ ] Merge + Pages deploy; `/download` and `/download.html` both show beta links