### PR TITLE
fix: github.io Pages base + Sonar S4036 update helpers

### DIFF
--- a/src/Titanium.Cli/Updates/VersionAndUpdateCommands.cs
+++ b/src/Titanium.Cli/Updates/VersionAndUpdateCommands.cs
@@ -320,7 +320,8 @@ internal static class CliUpdateApplyHelper
             File.WriteAllText(ps1, BuildWindowsScript(pid, zipPath, installDir, relaunchPath, version, channel), Encoding.UTF8);
             Process.Start(new ProcessStartInfo
             {
-                FileName = "powershell.exe",
+                // Absolute path: Sonar S4036 (PATH lookup for powershell.exe is a vulnerability).
+                FileName = ResolveWindowsPowerShellPath(),
                 Arguments = $"-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File \"{ps1}\"",
                 UseShellExecute = true,
                 CreateNoWindow = true,
@@ -340,6 +341,14 @@ internal static class CliUpdateApplyHelper
             WorkingDirectory = workDir,
         });
     }
+
+    /// <summary>Absolute Windows PowerShell path — avoids PATH-based Process.Start (Sonar S4036).</summary>
+    private static string ResolveWindowsPowerShellPath() =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "WindowsPowerShell",
+            "v1.0",
+            "powershell.exe");
 
     internal static string BuildWindowsScript(
         int pid,

--- a/src/Titanium.Inspector/Services/UpdateService.cs
+++ b/src/Titanium.Inspector/Services/UpdateService.cs
@@ -415,7 +415,8 @@ public static class UpdateApplyHelper
             File.WriteAllText(ps1, BuildWindowsScript(pid, kind, packagePath, installDir, relaunchPath, version, channel), Encoding.UTF8);
             Process.Start(new ProcessStartInfo
             {
-                FileName = "powershell.exe",
+                // Absolute path: Sonar S4036 (PATH lookup for powershell.exe is a vulnerability).
+                FileName = ResolveWindowsPowerShellPath(),
                 Arguments =
                     $"-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File \"{ps1}\"",
                 UseShellExecute = true,
@@ -436,6 +437,14 @@ public static class UpdateApplyHelper
             WorkingDirectory = workDir,
         });
     }
+
+    /// <summary>Absolute Windows PowerShell path — avoids PATH-based Process.Start (Sonar S4036).</summary>
+    private static string ResolveWindowsPowerShellPath() =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "WindowsPowerShell",
+            "v1.0",
+            "powershell.exe");
 
     public static string BuildWindowsScript(
         int pid,

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -1,14 +1,17 @@
 import { defineConfig } from 'vitepress'
 
 const repo = 'https://github.com/justcoding121/titanium-web-proxy'
+// Project Pages live at /titanium-web-proxy/ on github.io. CloudFront on
+// titaniumproxy.com maps both /… and /titanium-web-proxy/… to that origin, so
+// this base keeps CSS/JS loading on github.io without breaking the custom domain.
+const base = '/titanium-web-proxy/'
 
 export default defineConfig({
   title: 'Titanium Web Proxy',
   description:
     'High-performance HTTP(S) proxy — reverse/edge CLI, Plus ops, and Inspector on Windows, Linux, and macOS. Optional .NET library via NuGet.',
   lang: 'en-US',
-  // Served at https://titaniumproxy.com via CloudFront (origin path maps GitHub Pages project URL).
-  base: '/',
+  base,
   cleanUrls: true,
   lastUpdated: true,
   ignoreDeadLinks: true,
@@ -21,7 +24,7 @@ export default defineConfig({
     },
   },
   head: [
-    ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
+    ['link', { rel: 'icon', href: `${base}logo.svg`, type: 'image/svg+xml' }],
     ['meta', { name: 'theme-color', content: '#2B3A4A' }],
   ],
   themeConfig: {


### PR DESCRIPTION
## Summary
- **Website:** set VitePress `base` to `/titanium-web-proxy/` so [github.io download](https://justcoding121.github.io/titanium-web-proxy/download/) loads `/titanium-web-proxy/assets/…` (was requesting `/assets/…` → 404). CloudFront already serves that prefix on titaniumproxy.com.
- **Sonar:** Quality Gate failed on `new_security_rating` (B) from two **S4036** findings — `powershell.exe` via PATH in CLI/Inspector update apply helpers. Use absolute `System32\WindowsPowerShell\v1.0\powershell.exe`.

## Test plan
- [ ] Local/CI website build; after deploy, github.io `/download/` CSS returns 200
- [ ] titaniumproxy.com `/download/` and `/titanium-web-proxy/download/` still work
- [ ] Sonar on develop: S4036 issues closed; quality gate recovers after next analyze