### PR TITLE
fix(website): stop titaniumproxy.com/download redirecting to github.io

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -76,21 +76,22 @@ jobs:
             echo "Warning: docs/api missing; API pages will not be published"
           fi
 
-      # GitHub Pages + VitePress cleanUrls: publishing BOTH `download.html` and
-      # `download/index.html` leaves `/download` stuck on a stale object while
-      # `/download.html` updates. Mirror then remove the sibling `*.html` so only
-      # `dir/index.html` remains (nav `/download` and `/download/` both resolve).
+      # GitHub Pages cleanUrls: keep BOTH `page.html` and `page/index.html`.
+      # Deleting the sibling `.html` forces `/page` (no slash) through a Pages 301
+      # that rewrites the host to `*.github.io` when the custom-domain CNAME is not
+      # fully active on the edge (CloudFront → GitHub). That is what made
+      # titaniumproxy.com/download bounce to github.io.
       - name: Mirror cleanUrls HTML as index.html
         shell: bash
         run: |
           set -euo pipefail
           dist=website/.vitepress/dist
+          printf 'titaniumproxy.com\n' > "$dist/CNAME"
           for f in "$dist"/*.html; do
             base="$(basename "$f" .html)"
             [[ "$base" == "index" || "$base" == "404" ]] && continue
             mkdir -p "$dist/$base"
             cp -f "$f" "$dist/$base/index.html"
-            rm -f "$f"
           done
           # Nested docs pages
           if [ -d "$dist/docs" ]; then
@@ -99,7 +100,6 @@ jobs:
               dir="$(dirname "$f")"
               mkdir -p "$dir/$base"
               cp -f "$f" "$dir/$base/index.html"
-              rm -f "$f"
             done
           fi
 

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -1,17 +1,16 @@
 import { defineConfig } from 'vitepress'
 
 const repo = 'https://github.com/justcoding121/titanium-web-proxy'
-// Project Pages live at /titanium-web-proxy/ on github.io. CloudFront on
-// titaniumproxy.com maps both /… and /titanium-web-proxy/… to that origin, so
-// this base keeps CSS/JS loading on github.io without breaking the custom domain.
-const base = '/titanium-web-proxy/'
 
 export default defineConfig({
   title: 'Titanium Web Proxy',
   description:
     'High-performance HTTP(S) proxy — reverse/edge CLI, Plus ops, and Inspector on Windows, Linux, and macOS. Optional .NET library via NuGet.',
   lang: 'en-US',
-  base,
+  // CloudFront serves titaniumproxy.com from the GitHub Pages project origin with
+  // path mapping, so asset URLs must be site-root absolute (`/assets/...`), not
+  // `/titanium-web-proxy/assets/...`. The github.io project URL is secondary.
+  base: '/',
   cleanUrls: true,
   lastUpdated: true,
   ignoreDeadLinks: true,
@@ -24,7 +23,7 @@ export default defineConfig({
     },
   },
   head: [
-    ['link', { rel: 'icon', href: `${base}logo.svg`, type: 'image/svg+xml' }],
+    ['link', { rel: 'icon', href: '/logo.svg', type: 'image/svg+xml' }],
     ['meta', { name: 'theme-color', content: '#2B3A4A' }],
   ],
   themeConfig: {
@@ -32,8 +31,10 @@ export default defineConfig({
     siteTitle: 'Titanium Web Proxy',
     nav: [
       { text: 'Docs', link: '/docs/getting-started' },
-      { text: 'Download', link: '/download' },
-      { text: 'Releases', link: '/releases' },
+      // Trailing slash: with only dir/index.html, GitHub Pages 301s `/download` →
+      // github.io when the Pages custom-domain CNAME is not active on the edge.
+      { text: 'Download', link: '/download/' },
+      { text: 'Releases', link: '/releases/' },
       { text: 'API', link: '/api/Titanium.Web.Proxy.ProxyServer.html', target: '_blank' },
       { text: 'GitHub', link: repo },
     ],


### PR DESCRIPTION
## Root cause
Download **asset link generation is fine** (`download.data.ts` correctly lists v7.0.3-beta).

What broke UX:
1. Deploy mirrored `download.html` → `download/index.html` and **deleted** `download.html`.
2. `https://titaniumproxy.com/download` (no slash) then became a Pages **301** to add `/`.
3. With no effective Pages custom-domain CNAME on the edge, that 301 `Location` was `https://justcoding121.github.io/titanium-web-proxy/download/`.
4. On github.io with `base: '/'`, CSS/JS requested `/assets/…` → 404 (unstyled page). Later `base: /titanium-web-proxy/` made github.io look OK but users were still bounced off the custom domain.

## Fix
- Keep both `*.html` and `*/index.html` (no `rm`)
- Write `CNAME` (`titaniumproxy.com`) into the Pages artifact
- Revert VitePress `base` to `/` (matches CloudFront root mapping)
- Nav Download → `/download/`

## Test plan
- [ ] After deploy: `curl -sI https://titaniumproxy.com/download` is **200** (or 301 to `https://titaniumproxy.com/download/`, **not** github.io)
- [ ] `/download/` stays on titaniumproxy.com with Beta v7.0.3-beta links
- [ ] CSS loads (`/assets/*.css` → 200)