### PR TITLE
fix(website): remove Pages CNAME (CloudFront owns domain)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -86,7 +86,8 @@ jobs:
         run: |
           set -euo pipefail
           dist=website/.vitepress/dist
-          printf 'titaniumproxy.com\n' > "$dist/CNAME"
+          # Do NOT write a Pages CNAME: titaniumproxy.com DNS points at CloudFront,
+          # not GitHub. A Pages custom domain causes http↔https redirect loops.
           for f in "$dist"/*.html; do
             base="$(basename "$f" .html)"
             [[ "$base" == "index" || "$base" == "404" ]] && continue

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -111,12 +111,12 @@ jobs:
           path: website/.vitepress/dist
 
   deploy:
-    # github-pages environment protection allows develop only; beta/stable pushes
-    # still build (and can upload artifacts) but must not attempt Pages deploy.
+    # Push deploys only from develop (Pages env protection). Manual workflow_dispatch
+    # may publish from a fix branch to clear a bad artifact urgently.
     if: >
       github.event_name != 'pull_request' && (
         github.ref == 'refs/heads/develop' ||
-        (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop') ||
+        github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))
       )
     needs: build


### PR DESCRIPTION
## Why
Setting Pages `cname=titaniumproxy.com` while DNS points at CloudFront produced an infinite redirect loop (`http://titaniumproxy.com/download` ↔ `https://…`).

## Fix
- Clear Pages custom domain (done via API)
- Stop writing `CNAME` into the Pages artifact
- Keep the earlier fix: retain `download.html` + `download/index.html`

## Test plan
- [ ] `curl -sI https://titaniumproxy.com/download` → 200 (not github.io, not http loop)
- [ ] `/download/` 200 with v7.0.3-beta links