### PR TITLE
chore(release): bump to 7.0.4 for beta cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A lightweight, high-performance HTTP(S) proxy — reverse / edge CLI, desktop In
 | **Titanium.Cli** (`titanium` / `twp`) | Standalone reverse / edge proxy for any stack: `run`, `test`, `version`, `update` | [Download (Windows, Linux & Mac)](https://titaniumproxy.com/download#cli) |
 | **Titanium Inspector** | Desktop MITM debugger (session grid, inspectors, AutoResponder, breakpoints, HAR) | [Download (Windows, Linux & Mac)](https://titaniumproxy.com/download#inspector) |
 | **Titanium.Plus** | Optional advanced features: control plane, ops, observability, and dashboard | After installing CLI, run `titanium update --plus` |
-| **Titanium.Web.Proxy** | Core library. Embed a MITM and/or reverse proxy in a .NET app | [NuGet](https://www.nuget.org/packages/Titanium.Web.Proxy/7.0.3-beta) (`dotnet add package Titanium.Web.Proxy --prerelease`) |
+| **Titanium.Web.Proxy** | Core library. Embed a MITM and/or reverse proxy in a .NET app | [NuGet](https://www.nuget.org/packages/Titanium.Web.Proxy/7.0.4-beta) (`dotnet add package Titanium.Web.Proxy --prerelease`) |
 
 CLI and Plus target reverse-proxy / edge workloads (routing, load balancing, health, discovery) on Windows, Linux, and macOS. Inspector is the MITM debugging product. The Core library is the embed path for .NET. Requires .NET 10 or later.
 
@@ -67,7 +67,7 @@ On Windows, **winget is stable-only**:
 winget install justcoding121.TitaniumCli
 ```
 
-For **beta**, download self-contained zips from [Download](https://titaniumproxy.com/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when a product release includes `Titanium.Cli-*.zip` assets (e.g. `v7.0.3-beta`). Extract and run:
+For **beta**, download self-contained zips from [Download](https://titaniumproxy.com/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when a product release includes `Titanium.Cli-*.zip` assets (e.g. `v7.0.4-beta`). Extract and run:
 
 ```shell
 titanium run -c twp.yaml
@@ -82,7 +82,7 @@ Optional Plus: run `titanium update --plus` (add `--channel beta` for prerelease
 
 ### Titanium Inspector
 
-Prefer [Download](https://titaniumproxy.com/download). On Windows, winget id `justcoding121.TitaniumInspector` is **stable-only**; MSI / portable zip for beta come from the product `v*` release (e.g. `v7.0.3-beta`). Start interception from the Capture menu, install the root CA, then toggle system proxy.
+Prefer [Download](https://titaniumproxy.com/download). On Windows, winget id `justcoding121.TitaniumInspector` is **stable-only**; MSI / portable zip for beta come from the product `v*` release (e.g. `v7.0.4-beta`). Start interception from the Capture menu, install the root CA, then toggle system proxy.
 
 ## Quick start
 

--- a/src/Titanium.Cli/Titanium.Cli.csproj
+++ b/src/Titanium.Cli/Titanium.Cli.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>false</SignAssembly>
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Titanium Web Proxy CLI (titanium / twp).</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Titanium.Inspector/Services/SessionArchive.cs
+++ b/src/Titanium.Inspector/Services/SessionArchive.cs
@@ -18,7 +18,7 @@ public static class SessionArchive
             log = new
             {
                 version = "1.2",
-                creator = new { name = "Titanium Inspector", version = "7.0.3" },
+                creator = new { name = "Titanium Inspector", version = "7.0.4" },
                 entries,
             },
         };

--- a/src/Titanium.Inspector/Titanium.Inspector.csproj
+++ b/src/Titanium.Inspector/Titanium.Inspector.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>false</SignAssembly>
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Titanium Inspector desktop traffic debugger (PolyForm Noncommercial).</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Titanium.Plus/Titanium.Plus.csproj
+++ b/src/Titanium.Plus/Titanium.Plus.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Titanium Web Proxy Plus advanced features plugin (PolyForm Noncommercial).</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Titanium.Web.Proxy.Abstractions/Titanium.Web.Proxy.Abstractions.csproj
+++ b/src/Titanium.Web.Proxy.Abstractions/Titanium.Web.Proxy.Abstractions.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Shared contracts for Titanium Web Proxy routing, clusters, middleware, and plugins.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Titanium.Web.Proxy.Configuration/Titanium.Web.Proxy.Configuration.csproj
+++ b/src/Titanium.Web.Proxy.Configuration/Titanium.Web.Proxy.Configuration.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>YAML/JSON configuration binding for Titanium Web Proxy CLI and reverse-proxy documents.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Titanium.Web.Proxy/Properties/AssemblyInfo.cs
+++ b/src/Titanium.Web.Proxy/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Titanium.Web.Proxy")]
-[assembly: AssemblyCopyright("Copyright © Titanium 2015-2020")]
+[assembly: AssemblyCopyright("Copyright Â© Titanium 2015-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("Titanium.Web.Proxy.UnitTests, PublicKey=" +
@@ -65,5 +65,5 @@ using System.Runtime.InteropServices;
 // file-properties version disagreed with the package it was published in. Keep both of the values
 // below equal to <VersionPrefix> (as Major.Minor.Build.0) whenever that property changes.
 
-[assembly: AssemblyVersion("7.0.3.0")]
-[assembly: AssemblyFileVersion("7.0.3.0")]
+[assembly: AssemblyVersion("7.0.4.0")]
+[assembly: AssemblyFileVersion("7.0.4.0")]

--- a/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -13,7 +13,7 @@
     <!-- Keep in sync with the AssemblyVersion/AssemblyFileVersion attributes in
          Properties/AssemblyInfo.cs on every bump - GenerateAssemblyInfo is false below, so the SDK
          does not derive those attributes from this property automatically. -->
-    <VersionPrefix>7.0.3</VersionPrefix>
+    <VersionPrefix>7.0.4</VersionPrefix>
     <!-- The library itself is the canonical implementation of the TWP001 experimental HTTP/3 APIs.
          Suppress the diagnostic internally; consumers will still see it. -->
     <!--

--- a/tests/Titanium.Cli.Tests/UpdateCommandTests.cs
+++ b/tests/Titanium.Cli.Tests/UpdateCommandTests.cs
@@ -21,8 +21,8 @@ public class UpdateCommandTests
     [TestMethod]
     public void StripPrerelease_RemovesSuffix()
     {
-        Assert.AreEqual("7.0.3", VersionCommand.StripPrerelease("v7.0.3-beta"));
-        Assert.AreEqual("7.0.3", VersionCommand.StripPrerelease("7.0.3"));
+        Assert.AreEqual("7.0.4", VersionCommand.StripPrerelease("v7.0.4-beta"));
+        Assert.AreEqual("7.0.4", VersionCommand.StripPrerelease("7.0.4"));
     }
 
     [TestMethod]
@@ -33,7 +33,7 @@ public class UpdateCommandTests
             @"C:\temp\cli.zip",
             @"C:\tools\titanium",
             @"C:\tools\titanium\titanium.exe",
-            "7.0.3",
+            "7.0.4",
             "stable");
         StringAssert.Contains(script, "Expand-Archive");
         StringAssert.Contains(script, "7");
@@ -49,7 +49,7 @@ public class UpdateCommandTests
             "/tmp/cli.zip",
             "/opt/titanium",
             "/opt/titanium/titanium",
-            "7.0.3-beta",
+            "7.0.4-beta",
             "beta");
         StringAssert.Contains(script, "unzip");
         StringAssert.Contains(script, "beta");

--- a/tests/Titanium.E2E.Tests/CliCommandE2ETests.cs
+++ b/tests/Titanium.E2E.Tests/CliCommandE2ETests.cs
@@ -84,7 +84,7 @@ public class CliCommandE2ETests
         using var harness = new CliProcessHarness();
         var (code, stdout, _) = await harness.RunOnceAsync(["version"]);
         Assert.AreEqual(0, code);
-        StringAssert.Contains(stdout, "7.0.3");
+        StringAssert.Contains(stdout, "7.0.4");
     }
 
     [TestMethod]
@@ -346,7 +346,7 @@ public class CliCommandE2ETests
         var combined = stdout + stderr;
         // 0 = up to date, 2 = update available, 1 = feed unreachable (transient CI / network).
         Assert.IsTrue(code is 0 or 1 or 2, $"Unexpected exit {code}. Output: {combined}");
-        StringAssert.Contains(combined, "7.0.3");
+        StringAssert.Contains(combined, "7.0.4");
         if (code == 1)
         {
             StringAssert.Contains(combined, "Unable to query update feed");

--- a/tests/Titanium.Inspector.Tests/UpdateServiceTests.cs
+++ b/tests/Titanium.Inspector.Tests/UpdateServiceTests.cs
@@ -61,11 +61,11 @@ public class UpdateServiceTests
             @"C:\temp\a.msi",
             @"C:\Program Files\Titanium Inspector",
             @"C:\Program Files\Titanium Inspector\TitaniumInspector.exe",
-            "7.0.3",
+            "7.0.4",
             "Stable");
         StringAssert.Contains(script, "msiexec");
         StringAssert.Contains(script, "42");
-        StringAssert.Contains(script, "7.0.3");
+        StringAssert.Contains(script, "7.0.4");
         StringAssert.Contains(script, "Stable");
     }
 
@@ -77,7 +77,7 @@ public class UpdateServiceTests
             "/tmp/a.zip",
             "/opt/ti",
             "/opt/ti/TitaniumInspector",
-            "7.0.3-beta",
+            "7.0.4-beta",
             "Beta");
         StringAssert.Contains(script, "unzip");
         StringAssert.Contains(script, "99");

--- a/tools/RpsLoadProbe/PERF-GATES.md
+++ b/tools/RpsLoadProbe/PERF-GATES.md
@@ -103,7 +103,7 @@ Do not retune the harness to pass a gate — fix Core / CLI / Plus instead. Neve
   - Discovery-file **0.80**, metrics-scrape **0.80** vs CLI
   - lb-leasttime stays **0.85×**
 
-**Pre-beta note:** Gate 1/2 matrix, editions, cross-version, and product are green on `develop` as of 2026-08-29. Remaining before tag: feature freeze on the release SHA, then cut `v7.0.3-beta` (heavier wiki tables optional).
+**Pre-beta note:** Gate 1/2 matrix, editions, cross-version, and product are green on `develop` as of 2026-08-29. Remaining before tag: feature freeze on the release SHA, then cut `v7.0.4-beta` (heavier wiki tables optional).
 
 ### Fix-and-rerun policy
 

--- a/website/docs/inspector.md
+++ b/website/docs/inspector.md
@@ -20,8 +20,8 @@ winget install justcoding121.TitaniumInspector
 
 Windows examples for the **7.0 beta** product tag:
 
-- [MSI](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.3-beta/TitaniumInspector-win-x64.msi)
-- [Portable zip](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.3-beta/TitaniumInspector-win-x64.zip)
+- [MSI](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/TitaniumInspector-win-x64.msi)
+- [Portable zip](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/TitaniumInspector-win-x64.zip)
 
 ### Linux
 
@@ -47,7 +47,7 @@ chmod +x install-app.sh uninstall-app.sh TitaniumInspector
 
 ## Updates
 
-**Options → Update channel** — Stable (default) or Beta. **Help → Check for updates…** checks only that channel and labels it in the dialog (e.g. *Update 7.0.3 (Stable)*). Choosing **Install and restart** downloads the package (MSI for a Program Files install, otherwise the RID zip), closes Inspector, applies the update, and relaunches.
+**Options → Update channel** — Stable (default) or Beta. **Help → Check for updates…** checks only that channel and labels it in the dialog (e.g. *Update 7.0.4 (Stable)*). Choosing **Install and restart** downloads the package (MSI for a Program Files install, otherwise the RID zip), closes Inspector, applies the update, and relaunches.
 
 **Options → Check for updates on startup** uses the same channel and confirm dialog (never silent-install).
 

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -17,7 +17,7 @@ On Windows, **winget is stable-only**:
 winget install justcoding121.TitaniumCli
 ```
 
-For **beta** (or any OS), take a self-contained zip from the [Download](/download) page or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*.zip` assets are published (e.g. `v7.0.3-beta`).
+For **beta** (or any OS), take a self-contained zip from the [Download](/download) page or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*.zip` assets are published (e.g. `v7.0.4-beta`).
 
 Pick the **matching RID** (e.g. Alpine/K8s → `linux-musl-x64` or `linux-musl-arm64`, not `linux-x64`). HTTP/3 natives ship inside those zips — see [HTTP/3](/docs/http3).
 
@@ -45,7 +45,7 @@ Prefer [Download](/download). **winget is stable-only**:
 winget install justcoding121.TitaniumInspector
 ```
 
-Or MSI / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when those assets are published (beta example: `v7.0.3-beta`). Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
+Or MSI / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when those assets are published (beta example: `v7.0.4-beta`). Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
 
 ## See also
 

--- a/website/docs/library.md
+++ b/website/docs/library.md
@@ -4,7 +4,7 @@ NuGet package **Titanium.Web.Proxy** (MIT). Target framework: **.NET 10**.
 
 ```shell
 dotnet add package Titanium.Web.Proxy
-# Latest prerelease (e.g. 7.0.3-beta):
+# Latest prerelease (e.g. 7.0.4-beta):
 dotnet add package Titanium.Web.Proxy --prerelease
 ```
 


### PR DESCRIPTION
## Summary
- Bump product version to **7.0.4** / Assembly **7.0.4.0** for the next beta cut.
- `v7.0.3-beta` already shipped; without this bump, develop→beta would skip-duplicate NuGet and only move the old tag.

## Test plan
- [ ] develop CI build + ui-portable green
- [ ] After merge: PR develop → beta publishes `7.0.4-beta` + `v7.0.4-beta` assets