### PR TITLE
docs: 7.0.4 stable — winget stubs, NuGet/docs, PERF-GATES note

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A lightweight, high-performance HTTP(S) proxy — reverse / edge CLI, desktop In
 | **Titanium.Cli** (`titanium` / `twp`) | Standalone reverse / edge proxy for any stack: `run`, `test`, `version`, `update` | [Download (Windows, Linux & Mac)](https://titaniumproxy.com/download#cli) |
 | **Titanium Inspector** | Desktop MITM debugger (session grid, inspectors, AutoResponder, breakpoints, HAR) | [Download (Windows, Linux & Mac)](https://titaniumproxy.com/download#inspector) |
 | **Titanium.Plus** | Optional advanced features: control plane, ops, observability, and dashboard | After installing CLI, run `titanium update --plus` |
-| **Titanium.Web.Proxy** | Core library. Embed a MITM and/or reverse proxy in a .NET app | [NuGet](https://www.nuget.org/packages/Titanium.Web.Proxy/7.0.4-beta) (`dotnet add package Titanium.Web.Proxy --prerelease`) |
+| **Titanium.Web.Proxy** | Core library. Embed a MITM and/or reverse proxy in a .NET app | [NuGet](https://www.nuget.org/packages/Titanium.Web.Proxy/7.0.4) (`dotnet add package Titanium.Web.Proxy`) |
 
 CLI and Plus target reverse-proxy / edge workloads (routing, load balancing, health, discovery) on Windows, Linux, and macOS. Inspector is the MITM debugging product. The Core library is the embed path for .NET. Requires .NET 10 or later.
 
@@ -67,7 +67,7 @@ On Windows, **winget is stable-only**:
 winget install justcoding121.TitaniumCli
 ```
 
-For **beta**, download self-contained zips from [Download](https://titaniumproxy.com/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when a product release includes `Titanium.Cli-*.zip` assets (e.g. `v7.0.4-beta`). Extract and run:
+For **beta**, download self-contained zips from [Download](https://titaniumproxy.com/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when a product release includes `Titanium.Cli-*.zip` assets (e.g. `v7.0.4-beta`; stable is `v7.0.4`). Extract and run:
 
 ```shell
 titanium run -c twp.yaml
@@ -82,7 +82,7 @@ Optional Plus: run `titanium update --plus` (add `--channel beta` for prerelease
 
 ### Titanium Inspector
 
-Prefer [Download](https://titaniumproxy.com/download). On Windows, winget id `justcoding121.TitaniumInspector` is **stable-only**; MSI / portable zip for beta come from the product `v*` release (e.g. `v7.0.4-beta`). Start interception from the Capture menu, install the root CA, then toggle system proxy.
+Prefer [Download](https://titaniumproxy.com/download). On Windows, winget id `justcoding121.TitaniumInspector` is **stable-only** (currently `v7.0.4`); MSI / portable zip for beta come from the product `v*` release (e.g. `v7.0.4-beta`). Start interception from the Capture menu, install the root CA, then toggle system proxy.
 
 ## Quick start
 

--- a/tools/RpsLoadProbe/PERF-GATES.md
+++ b/tools/RpsLoadProbe/PERF-GATES.md
@@ -18,33 +18,33 @@ Product version is **`7.0.0.0`**; gates block beta/stable tags, not feature comm
 
 | Event | RPS mode | Blocks |
 |-------|----------|--------|
-| Push to `beta` / `stable` (NuGet `publish`) | `compare-editions` via `.NET / rps-publish-gate` **and** `compare-spot` via `.NET / rps-peer-gate` (parallel; Core÷YARP + MITM÷Reverse @ c=64) | NuGet publish |
+| Push to `beta` / `stable` (NuGet `publish`) | `compare-editions` via `.NET / rps-publish-gate` **and** `compare-spot` via `.NET / rps-peer-gate` (parallel; CoreÃ·YARP + MITMÃ·Reverse @ c=64) | NuGet publish |
 | Tag `v*` product release | `compare-product` (manual / release workflow) | GitHub Release product assets |
 
-`rps-peer-gate` re-checks Core vs YARP on the merge SHA so a uniform Core slowdown cannot hide behind green edition ratios. It runs in parallel with editions, so publish wall clock stays ~max(editions ≈60m, spot ≈10–20m).
+`rps-peer-gate` re-checks Core vs YARP on the merge SHA so a uniform Core slowdown cannot hide behind green edition ratios. It runs in parallel with editions, so publish wall clock stays ~max(editions â60m, spot â10â20m).
 
-Do **not** run full `compare-product` on every develop PR. Thresholds change only with written rationale here + commit — never loosen gates silently to go green.
+Do **not** run full `compare-product` on every develop PR. Thresholds change only with written rationale here + commit â never loosen gates silently to go green.
 
 ## Tiered cadence (when to run which mode)
 
 | Tier | When | Mode | Wall-clock |
 |------|------|------|------------|
 | Daily / develop PR | feature commits (advisory) | `compare-spot` ([`run-spot-matrix.ps1`](run-spot-matrix.ps1)) | minutes |
-| Milestone / investigation | before merge to main | `compare-terminate` or `compare-matrix` | ~1–2h |
+| Milestone / investigation | before merge to main | `compare-terminate` or `compare-matrix` | ~1â2h |
 | Editions | after CLI/Plus changes | `compare-editions` + [`validate-edition-gates.ps1`](validate-edition-gates.ps1) | ~60 min |
 | Beta / stable publish | push to `beta`/`stable` | `compare-editions` + parallel `compare-spot` ([`run-spot-matrix.ps1`](run-spot-matrix.ps1)) | ~60 min wall |
-| Cross-version (Gate 2) | before `v7.0.0` tag | `compare-cross-version` + [`validate-cross-version.ps1`](validate-cross-version.ps1) | ~1–2h |
-| Release / wiki refresh | release SHA | `compare-product` (median of 3) on `ubuntu-latest` + `windows-latest` + `macos-15-intel` | ~3–4h |
-| Heavier wiki tables | as needed | `compare-bodies` / `post` / `lossy` / `arch` / `bridges` / `tls-cost` (independent dispatch) | 30–60 min each |
+| Cross-version (Gate 2) | before `v7.0.0` tag | `compare-cross-version` + [`validate-cross-version.ps1`](validate-cross-version.ps1) | ~1â2h |
+| Release / wiki refresh | release SHA | `compare-product` (median of 3) on `ubuntu-latest` + `windows-latest` + `macos-15-intel` | ~3â4h |
+| Heavier wiki tables | as needed | `compare-bodies` / `post` / `lossy` / `arch` / `bridges` / `tls-cost` (independent dispatch) | 30â60 min each |
 
-Do **not** run full `compare-product` as a daily smoke. Prefer TWP÷YARP / TWP÷nginx / edition ratios over absolute RPS. Early-stop (`--stop-on-slo-fail`, default on) aborts an arm after the first SLO fail plus one peak confirmation step.
+Do **not** run full `compare-product` as a daily smoke. Prefer TWPÃ·YARP / TWPÃ·nginx / edition ratios over absolute RPS. Early-stop (`--stop-on-slo-fail`, default on) aborts an arm after the first SLO fail plus one peak confirmation step.
 
 ## Gate 1 (after Core route wire)
 
 - [x] Probe config: routes **unset** / null `ReverseProxy` (zero-cost default)
 - [x] Plus / Inspector DLLs **not** loaded by the probe process (library arms); edition arms spawn CLI externally
-- [x] Full matrix (ubuntu+windows, `compare-matrix`) — GHA [33151235741](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33151235741) @ `d1e0c65c` **success** both OS. Absolute RPS vs prior medians (`33087091622` / `33087088466`) swings with runner heat (Win down / Linux up); **peer-normalized** TWP÷YARP is the regression signal (same policy as Gate 2 cross-version). A few Win peer-norm cells dipped under 0.90 on that older SHA — re-locked on current `develop` via Gate 2 matrix below.
-- [x] Additional: single-route table ≡ ForwardHost within **10%** RPS of pure ForwardHost on the same build (`twp-cli-reverse-http1-route` ÷ `twp-cli-reverse-http1` ≥ **0.90**)
+- [x] Full matrix (ubuntu+windows, `compare-matrix`) â GHA [33151235741](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33151235741) @ `d1e0c65c` **success** both OS. Absolute RPS vs prior medians (`33087091622` / `33087088466`) swings with runner heat (Win down / Linux up); **peer-normalized** TWPÃ·YARP is the regression signal (same policy as Gate 2 cross-version). A few Win peer-norm cells dipped under 0.90 on that older SHA â re-locked on current `develop` via Gate 2 matrix below.
+- [x] Additional: single-route table â¡ ForwardHost within **10%** RPS of pure ForwardHost on the same build (`twp-cli-reverse-http1-route` Ã· `twp-cli-reverse-http1` â¥ **0.90**)
 
 **Runs (2026-08-28, `develop` @ `d1e0c65c`):**
 
@@ -53,57 +53,59 @@ Do **not** run full `compare-product` as a daily smoke. Prefer TWP÷YARP / TWP÷
 | Gate 1 terminate | `compare-terminate` | **success** | https://github.com/justcoding121/titanium-web-proxy/actions/runs/33151234059 |
 | Gate 1 matrix | `compare-matrix` | **success** | https://github.com/justcoding121/titanium-web-proxy/actions/runs/33151235741 |
 
-Terminate smoke (peak RPS; routes unset): TWP H1 TLS win **34273**, ubuntu **24171** — ahead of YARP on H1/H2c arms in that run.
+Terminate smoke (peak RPS; routes unset): TWP H1 TLS win **34273**, ubuntu **24171** â ahead of YARP on H1/H2c arms in that run.
 
 ## Gate 2 (before first beta / `v7.0.0` stable tag)
 
-- [x] Same unset-routes probe matrix as gate 1 — GHA [33263427055](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33263427055) `compare-matrix` both OS **success** @ `3d9aba23`
+- [x] Same unset-routes probe matrix as gate 1 â GHA [33263427055](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33263427055) `compare-matrix` both OS **success** @ `3d9aba23`
 - [x] Plus / Inspector DLLs still absent from probe library path (`RpsLoadProbe` references Core only)
-- [x] **Cross-version:** GHA [33270571908](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33270571908) @ `0ef6d4dd` both OS **success** (RSS floor **1.20**; peer-norm ≥ **0.90** or current TWP÷YARP ≥ **0.90**). Prior Win fail [33263428508](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33263428508) was YARP spike + RSS noise on H1→h2c / H3.
-- [x] **Editions:** `compare-editions` passes [`validate-edition-gates.ps1`](validate-edition-gates.ps1) on both Win and Linux — GHA [33259699099](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33259699099) @ `6d2a7c9d` (median of 3; middleware-on-lite + JWT cache)
-- [x] **Product:** `compare-product` median of 3 — GHA [33263425394](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33263425394) @ `3d9aba23` Win+Linux **success**; MITM÷Reverse ≥ 0.70 and reverse TWP÷YARP ≥ 0.95 (Linux H3→H3 YARP peer SLO-fail skipped — harness, not TWP). Wiki Win/Linux tables refreshed.
-- [x] **Product (macOS Intel):** GHA [33480574506](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33480574506) @ `af6feb9c` — `compare-product` matrix leg on `macos-15-intel` (4-core / 14 GB; nginx `http_v3_module` + MsQuic + YARP). Workflow passes Mac-only floors into [`validate-compare-product-gates.ps1`](validate-compare-product-gates.ps1): **H3→H1 TLS Full ≥ 0.65**, **H1 plain Full ≥ 0.55**, **H3→H1 TWP÷YARP ≥ 0.55**, **H3→H3 TWP÷YARP ≥ 0.74** (measured medians include 0.746 @ `af6feb9c` run 33480574506). Shared: MITM÷Reverse ≥ **0.70** (other pairs), **H3→H3 MITM ≥ 0.69**. Win/Linux keep H3→H1 TWP÷YARP ≥ **0.95**, H3→H3 peer ≥ **0.75**, H1 Full ≥ **0.70**. No cross-OS absolute-RPS gates. Fill `wiki/Performance.md` Mac Reverse + MITM via `paste-compare-product-wiki.ps1` / `apply-wiki-paste.ps1`.
+- [x] **Cross-version:** GHA [33270571908](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33270571908) @ `0ef6d4dd` both OS **success** (RSS floor **1.20**; peer-norm â¥ **0.90** or current TWPÃ·YARP â¥ **0.90**). Prior Win fail [33263428508](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33263428508) was YARP spike + RSS noise on H1âh2c / H3.
+- [x] **Editions:** `compare-editions` passes [`validate-edition-gates.ps1`](validate-edition-gates.ps1) on both Win and Linux â GHA [33259699099](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33259699099) @ `6d2a7c9d` (median of 3; middleware-on-lite + JWT cache)
+- [x] **Product:** `compare-product` median of 3 â GHA [33263425394](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33263425394) @ `3d9aba23` Win+Linux **success**; MITMÃ·Reverse â¥ 0.70 and reverse TWPÃ·YARP â¥ 0.95 (Linux H3âH3 YARP peer SLO-fail skipped â harness, not TWP). Wiki Win/Linux tables refreshed.
+- [x] **Product (macOS Intel):** GHA [33480574506](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33480574506) @ `af6feb9c` â `compare-product` matrix leg on `macos-15-intel` (4-core / 14 GB; nginx `http_v3_module` + MsQuic + YARP). Workflow passes Mac-only floors into [`validate-compare-product-gates.ps1`](validate-compare-product-gates.ps1): **H3âH1 TLS Full â¥ 0.65**, **H1 plain Full â¥ 0.55**, **H3âH1 TWPÃ·YARP â¥ 0.55**, **H3âH3 TWPÃ·YARP â¥ 0.74** (measured medians include 0.746 @ `af6feb9c` run 33480574506). Shared: MITMÃ·Reverse â¥ **0.70** (other pairs), **H3âH3 MITM â¥ 0.69**. Win/Linux keep H3âH1 TWPÃ·YARP â¥ **0.95**, H3âH3 peer â¥ **0.75**, H1 Full â¥ **0.70**. No cross-OS absolute-RPS gates. Fill `wiki/Performance.md` Mac Reverse + MITM via `paste-compare-product-wiki.ps1` / `apply-wiki-paste.ps1`.
 
-**Mac H3→HTTPS-HTTP1 (2026-08-31):** first 3-OS compare-product [33436678752](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33436678752) Mac failed validate — TWP H3→H1 TLS arms were 100% `H3_INTERNAL_ERROR` because `ForwardOverTcpFastAsync` used `ForwardHost` (`127.0.0.1`) as TLS SNI against a `localhost` leaf (macOS Network.framework). Fixed: SNI = `:authority` / `OriginAuthorityHost`, connect = `ForwardHost` (same split as H3→H2/H3→H3).
+**Mac H3âHTTPS-HTTP1 (2026-08-31):** first 3-OS compare-product [33436678752](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33436678752) Mac failed validate â TWP H3âH1 TLS arms were 100% `H3_INTERNAL_ERROR` because `ForwardOverTcpFastAsync` used `ForwardHost` (`127.0.0.1`) as TLS SNI against a `localhost` leaf (macOS Network.framework). Fixed: SNI = `:authority` / `OriginAuthorityHost`, connect = `ForwardHost` (same split as H3âH2/H3âH3).
 
 ### Edition ratio gates (first-run estimates; lock after first clean Win+Linux baseline)
 
 | Arm | Baseline | Gate |
 |-----|----------|------|
-| `twp-cli-reverse-http1` | `twp-reverse-http1` | ≥ **0.80×** |
-| `twp-cli-reverse-http1-tls` | `twp-reverse-http1-tls` | ≥ **0.80×** |
-| `twp-cli-reverse-http1-route` | `twp-cli-reverse-http1` | ≥ **0.90×** |
-| `twp-cli-plus-base-http1` | `twp-cli-reverse-http1` | ≥ **0.90×** |
-| `twp-cli-plus-cache-http1` | `twp-cli-reverse-http1` | ≥ **0.70×** |
-| `twp-cli-intercept-http1` | `twp-cli-reverse-http1` | ≥ **0.70×** |
-| `twp-cli-plus-waf-http1` | `twp-cli-reverse-http1` | ≥ **0.80×** |
-| `twp-cli-plus-cidr-http1` | `twp-cli-reverse-http1` | ≥ **0.80×** |
-| `twp-cli-plus-jwt-http1` | `twp-cli-reverse-http1` | ≥ **0.70×** |
-| `twp-cli-plus-ratelimit-http1` | `twp-cli-reverse-http1` | ≥ **0.80×** |
-| `twp-cli-plus-resilience-http1` | `twp-cli-reverse-http1` | ≥ **0.85×** |
-| `twp-cli-plus-discovery-file-http1` | `twp-cli-reverse-http1` | ≥ **0.80×** |
-| `twp-cli-plus-metrics-scrape-http1` | `twp-cli-reverse-http1` | ≥ **0.80×** |
-| `twp-cli-plus-cache-hit-http1` | `twp-cli-plus-cache-http1` (cold) | ≥ **0.90×** |
-| `twp-cli-static-http1` | `twp-cli-reverse-http1` | ≥ **0.85×** |
-| `twp-cli-logging-http1` | `twp-cli-reverse-http1` | ≥ **0.90×** |
-| `twp-cli-lb-leasttime-http1` | `twp-cli-reverse-http1-route` | ≥ **0.85×** |
-| `twp-cli-dialect-twp-http1` | `twp-cli-reverse-http1` | ≥ **0.90×** |
+| `twp-cli-reverse-http1` | `twp-reverse-http1` | â¥ **0.80Ã** |
+| `twp-cli-reverse-http1-tls` | `twp-reverse-http1-tls` | â¥ **0.80Ã** |
+| `twp-cli-reverse-http1-route` | `twp-cli-reverse-http1` | â¥ **0.90Ã** |
+| `twp-cli-plus-base-http1` | `twp-cli-reverse-http1` | â¥ **0.90Ã** |
+| `twp-cli-plus-cache-http1` | `twp-cli-reverse-http1` | â¥ **0.70Ã** |
+| `twp-cli-intercept-http1` | `twp-cli-reverse-http1` | â¥ **0.70Ã** |
+| `twp-cli-plus-waf-http1` | `twp-cli-reverse-http1` | â¥ **0.80Ã** |
+| `twp-cli-plus-cidr-http1` | `twp-cli-reverse-http1` | â¥ **0.80Ã** |
+| `twp-cli-plus-jwt-http1` | `twp-cli-reverse-http1` | â¥ **0.70Ã** |
+| `twp-cli-plus-ratelimit-http1` | `twp-cli-reverse-http1` | â¥ **0.80Ã** |
+| `twp-cli-plus-resilience-http1` | `twp-cli-reverse-http1` | â¥ **0.85Ã** |
+| `twp-cli-plus-discovery-file-http1` | `twp-cli-reverse-http1` | â¥ **0.80Ã** |
+| `twp-cli-plus-metrics-scrape-http1` | `twp-cli-reverse-http1` | â¥ **0.80Ã** |
+| `twp-cli-plus-cache-hit-http1` | `twp-cli-plus-cache-http1` (cold) | â¥ **0.90Ã** |
+| `twp-cli-static-http1` | `twp-cli-reverse-http1` | â¥ **0.85Ã** |
+| `twp-cli-logging-http1` | `twp-cli-reverse-http1` | â¥ **0.90Ã** |
+| `twp-cli-lb-leasttime-http1` | `twp-cli-reverse-http1-route` | â¥ **0.85Ã** |
+| `twp-cli-dialect-twp-http1` | `twp-cli-reverse-http1` | â¥ **0.90Ã** |
 
-Do not retune the harness to pass a gate — fix Core / CLI / Plus instead. Never adjust a gate threshold without a written reason here and a commit message. Thresholds lock after a clean Win+Linux compare-editions pass.
+Do not retune the harness to pass a gate â fix Core / CLI / Plus instead. Never adjust a gate threshold without a written reason here and a commit message. Thresholds lock after a clean Win+Linux compare-editions pass.
 
 **Lock notes (local Win + Docker Linux, 2026-08-29):**
-- **Route / dialect `.twp` → 0.90×:** Locked at **0.90** (within 10% of ForwardHost). Local Win/Linux measured route ≥0.969× and dialect ≥0.948×.
+- **Route / dialect `.twp` â 0.90Ã:** Locked at **0.90** (within 10% of ForwardHost). Local Win/Linux measured route â¥0.969Ã and dialect â¥0.948Ã.
 - **Plus middleware on terminate-lite (2026-08-29):** Pre-origin middleware no longer forces the full `SessionEventArgs` path. Lite populates `ProxyMiddlewareContext` (client IP + request view); deny uses handled status fields. JWT caches successful bearer validations until near `exp` (same token under load skips RS256). Cool paired Win:
-  - JWT ≈ **0.78×** (was ~0.51×) → gate **0.70×**
-  - CIDR/WAF/rate-limit ≈ **0.88–0.91×** → gate **0.80×**
-  - Cache (loopback; fills then hits) ≈ **0.99×** → gate **0.70×** (session + AfterResponse on miss; hits skip origin)
+  - JWT â **0.78Ã** (was ~0.51Ã) â gate **0.70Ã**
+  - CIDR/WAF/rate-limit â **0.88â0.91Ã** â gate **0.80Ã**
+  - Cache (loopback; fills then hits) â **0.99Ã** â gate **0.70Ã** (session + AfterResponse on miss; hits skip origin)
 - **Noise / measured floors tightened:**
   - Plus-base **0.90**, cache-hit **0.90**, intercept **0.70**
-  - Resilience **0.85** (health probes; measured ~1.0×)
+  - Resilience **0.85** (health probes; measured ~1.0Ã)
   - Discovery-file **0.80**, metrics-scrape **0.80** vs CLI
-  - lb-leasttime stays **0.85×**
+  - lb-leasttime stays **0.85Ã**
 
 **Pre-beta note:** Gate 1/2 matrix, editions, cross-version, and product are green on `develop` as of 2026-08-29. Remaining before tag: feature freeze on the release SHA, then cut `v7.0.4-beta` (heavier wiki tables optional).
+
+**Stable cut (2026-09-01):** `v7.0.4` GA shipped from `beta` → `stable` (NuGet `7.0.4`, non-prerelease product release, `/download` Stable links refreshed).
 
 ### Fix-and-rerun policy
 

--- a/tools/packaging/winget/TitaniumCli.yaml
+++ b/tools/packaging/winget/TitaniumCli.yaml
@@ -1,6 +1,6 @@
 # justcoding121.TitaniumCli
 PackageIdentifier: justcoding121.TitaniumCli
-PackageVersion: 7.0.0
+PackageVersion: 7.0.4
 PackageLocale: en-US
 Publisher: justcoding121
 PackageName: Titanium CLI
@@ -15,7 +15,7 @@ Installers:
         PortableCommandAlias: titanium
       - RelativeFilePath: titanium.exe
         PortableCommandAlias: twp
-    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.0/Titanium.Cli-win-x64.zip
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/Titanium.Cli-win-x64.zip
+    InstallerSha256: 67fe922f04d4fddd08a3d459459efda9601b2e814bcdaa8c2c40858fa2bf841a
 ManifestType: singleton
 ManifestVersion: 1.6.0

--- a/tools/packaging/winget/TitaniumInspector.yaml
+++ b/tools/packaging/winget/TitaniumInspector.yaml
@@ -2,7 +2,7 @@
 # Submit a PR to https://github.com/microsoft/winget-pkgs after a GitHub Release with MSI.
 
 PackageIdentifier: justcoding121.TitaniumInspector
-PackageVersion: 7.0.0
+PackageVersion: 7.0.4
 PackageLocale: en-US
 Publisher: justcoding121
 PublisherUrl: https://github.com/justcoding121/titanium-web-proxy
@@ -12,11 +12,11 @@ ShortDescription: Desktop HTTP(S) traffic debugger for Titanium Web Proxy.
 Installers:
   - Architecture: x64
     InstallerType: wix
-    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.0/TitaniumInspector-win-x64.msi
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-win-x64.msi
+    InstallerSha256: 94a19f24226f6d99bccc9abb2604feddf10b6d68bc13d696baac3e7ac2c9decb
   - Architecture: x64
     InstallerType: portable
-    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.0/TitaniumInspector-win-x64.zip
-    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-win-x64.zip
+    InstallerSha256: 59c3fd049596233f9985e223e05fb9529d42ce4aff9abd69f759de53e02d3348
 ManifestType: singleton
 ManifestVersion: 1.6.0

--- a/website/docs/inspector.md
+++ b/website/docs/inspector.md
@@ -14,11 +14,16 @@ Prefer the [Download](/download) page (resolves the newest release that has Insp
 - **Portable zip** — extract and run `TitaniumInspector.exe`.
 
 ```shell
-# Stable community package only — not the 7.0 beta
+# Stable community package (v7.0.4)
 winget install justcoding121.TitaniumInspector
 ```
 
-Windows examples for the **7.0 beta** product tag:
+Windows **stable** (`v7.0.4`):
+
+- [MSI](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-win-x64.msi)
+- [Portable zip](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-win-x64.zip)
+
+Windows **beta** (`v7.0.4-beta`):
 
 - [MSI](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/TitaniumInspector-win-x64.msi)
 - [Portable zip](https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/TitaniumInspector-win-x64.zip)

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -6,6 +6,7 @@ Full download buttons live on the [Download](/download) page. This page is the s
 
 ```shell
 dotnet add package Titanium.Web.Proxy
+# Prerelease when newer than stable:
 dotnet add package Titanium.Web.Proxy --prerelease
 ```
 
@@ -17,7 +18,7 @@ On Windows, **winget is stable-only**:
 winget install justcoding121.TitaniumCli
 ```
 
-For **beta** (or any OS), take a self-contained zip from the [Download](/download) page or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*.zip` assets are published (e.g. `v7.0.4-beta`).
+Stable CLI zips are on the [Download](/download) page (`v7.0.4`). For **beta** (or any OS), use the beta section or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*.zip` assets are published (e.g. `v7.0.4-beta`).
 
 Pick the **matching RID** (e.g. Alpine/K8s → `linux-musl-x64` or `linux-musl-arm64`, not `linux-x64`). HTTP/3 natives ship inside those zips — see [HTTP/3](/docs/http3).
 
@@ -45,7 +46,7 @@ Prefer [Download](/download). **winget is stable-only**:
 winget install justcoding121.TitaniumInspector
 ```
 
-Or MSI / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when those assets are published (beta example: `v7.0.4-beta`). Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
+Or MSI / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) (stable: `v7.0.4`; beta example: `v7.0.4-beta`). Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
 
 ## See also
 

--- a/website/docs/library.md
+++ b/website/docs/library.md
@@ -4,7 +4,7 @@ NuGet package **Titanium.Web.Proxy** (MIT). Target framework: **.NET 10**.
 
 ```shell
 dotnet add package Titanium.Web.Proxy
-# Latest prerelease (e.g. 7.0.4-beta):
+# Prerelease (e.g. 7.0.4-beta when newer than stable):
 dotnet add package Titanium.Web.Proxy --prerelease
 ```
 


### PR DESCRIPTION
Follow-up after v7.0.4 stable cut (PR #1011).

- Update winget YAML stubs to 7.0.4 with real SHA256 hashes from v7.0.4 release assets
- README/docs prefer stable NuGet 7.0.4; beta remains secondary
- PERF-GATES: note v7.0.4 GA shipped

Winget-pkgs PRs to follow separately.