### PR TITLE
fix(winget): TitaniumCli stub twp alias points to twp.exe

### DIFF
--- a/tools/packaging/winget/TitaniumCli.yaml
+++ b/tools/packaging/winget/TitaniumCli.yaml
@@ -13,7 +13,7 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: titanium.exe
         PortableCommandAlias: titanium
-      - RelativeFilePath: titanium.exe
+      - RelativeFilePath: twp.exe
         PortableCommandAlias: twp
     InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/Titanium.Cli-win-x64.zip
     InstallerSha256: 67fe922f04d4fddd08a3d459459efda9601b2e814bcdaa8c2c40858fa2bf841a


### PR DESCRIPTION
Align stub with actual CLI zip layout (	itanium.exe + 	wp.exe). Matches winget-pkgs PR #427560 fix.