### PR TITLE
ci(release): Azure Artifact Signing for Windows assets

### DIFF
--- a/.github/actions/azure-artifact-sign/action.yml
+++ b/.github/actions/azure-artifact-sign/action.yml
@@ -1,0 +1,47 @@
+name: Azure Artifact Sign
+description: Sign PE/MSI files with Azure Artifact Signing (OIDC via azure/login in the caller)
+
+inputs:
+  files:
+    description: Comma or newline-separated absolute paths to sign
+    required: true
+  endpoint:
+    description: Artifact Signing account endpoint
+    required: true
+  signing-account-name:
+    description: Artifact Signing account name
+    required: true
+  certificate-profile-name:
+    description: Certificate profile name
+    required: true
+  description:
+    description: Authenticode description
+    required: false
+    default: Titanium Web Proxy
+
+runs:
+  using: composite
+  steps:
+    - name: Sign files
+      uses: azure/artifact-signing-action@v2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        signing-account-name: ${{ inputs.signing-account-name }}
+        certificate-profile-name: ${{ inputs.certificate-profile-name }}
+        files: ${{ inputs.files }}
+        file-digest: SHA256
+        timestamp-rfc3161: http://timestamp.acs.microsoft.com
+        timestamp-digest: SHA256
+        description: ${{ inputs.description }}
+        description-url: https://github.com/justcoding121/titanium-web-proxy
+        # azure/login already established Azure CLI; skip slower credential types.
+        exclude-environment-credential: true
+        exclude-workload-identity-credential: true
+        exclude-managed-identity-credential: true
+        exclude-shared-token-cache-credential: true
+        exclude-visual-studio-credential: true
+        exclude-visual-studio-code-credential: true
+        exclude-azure-cli-credential: false
+        exclude-azure-powershell-credential: true
+        exclude-azure-developer-cli-credential: true
+        exclude-interactive-browser-credential: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,11 @@ jobs:
   build-cli:
     needs: [resolve-version, test]
     runs-on: ${{ matrix.os }}
+    # win-x64 uses environment "signing" for Azure OIDC (federated cred).
+    environment: ${{ matrix.rid == 'win-x64' && 'signing' || '' }}
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       # Cap concurrency — many self-contained publishes on shared ubuntu runners run out of disk.
@@ -127,7 +130,7 @@ jobs:
           - rid: linux-musl-arm64
             os: ubuntu-latest
           - rid: win-x64
-            os: ubuntu-latest
+            os: windows-latest
           - rid: osx-x64
             os: macos-latest
           - rid: osx-arm64
@@ -161,6 +164,29 @@ jobs:
             Copy-Item "$out/titanium" "$out/twp"
           }
           ./tools/packaging/bundle-http3-native.ps1 -Rid $rid -PublishDir $out
+      - name: Azure login (OIDC)
+        if: matrix.rid == 'win-x64'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign CLI Windows binaries
+        if: matrix.rid == 'win-x64'
+        uses: ./.github/actions/azure-artifact-sign
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
+          description: Titanium Web Proxy CLI
+          files: |
+            ${{ github.workspace }}\artifacts\cli\win-x64\titanium.exe
+            ${{ github.workspace }}\artifacts\cli\win-x64\twp.exe
+      - name: Zip Cli
+        shell: pwsh
+        run: |
+          $rid = "${{ matrix.rid }}"
+          $out = "artifacts/cli/$rid"
           if ($IsWindows) {
             Compress-Archive -Path "$out/*" -DestinationPath "Titanium.Cli-$rid.zip"
           } else {
@@ -196,8 +222,10 @@ jobs:
   build-inspector:
     needs: [resolve-version, test]
     runs-on: ${{ matrix.os }}
+    environment: ${{ matrix.rid == 'win-x64' && 'signing' || '' }}
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -256,6 +284,27 @@ jobs:
           if ($rid -like 'osx*') {
             Copy-Item -Force tools/packaging/osx/install-app.sh, tools/packaging/osx/uninstall-app.sh $out
           }
+      - name: Azure login (OIDC)
+        if: matrix.rid == 'win-x64'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign Inspector Windows binary
+        if: matrix.rid == 'win-x64'
+        uses: ./.github/actions/azure-artifact-sign
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
+          description: Titanium Inspector
+          files: ${{ github.workspace }}\artifacts\inspector\win-x64\TitaniumInspector.exe
+      - name: Zip Inspector
+        shell: pwsh
+        run: |
+          $rid = "${{ matrix.rid }}"
+          $out = "artifacts/inspector/$rid"
           if ($IsWindows) {
             Compress-Archive -Path "$out/*" -DestinationPath "TitaniumInspector-$rid.zip"
           } else {
@@ -275,6 +324,15 @@ jobs:
             -PayloadDir artifacts/inspector/win-x64 `
             -OutputMsi TitaniumInspector-win-x64.msi `
             -Version $ver
+      - name: Sign Inspector MSI
+        if: matrix.msi
+        uses: ./.github/actions/azure-artifact-sign
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
+          description: Titanium Inspector
+          files: ${{ github.workspace }}\TitaniumInspector-win-x64.msi
       - uses: actions/upload-artifact@v4
         with:
           name: inspector-${{ matrix.rid }}

--- a/tools/packaging/PACKAGING.md
+++ b/tools/packaging/PACKAGING.md
@@ -41,7 +41,7 @@ Uses WiX 5 (`dotnet tool` manifest under `tools/packaging/wix/`) plus **WixTools
 - **Launch Titanium Inspector** checkbox on the exit dialog (first install and upgrades)
 - `CloseApplication` for `TitaniumInspector.exe` so manual MSI upgrades can close a running instance
 
-Authenticode signing is stretch; unsigned MSI is fine for GitHub Releases / early winget.
+Windows Authenticode uses [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart) in [`release.yml`](../../.github/workflows/release.yml) (`win-x64` CLI `titanium.exe`/`twp.exe`, `TitaniumInspector.exe`, and the MSI). Publisher is the validated individual identity (currently `CN=Jehonathan Thomas`). Leaf certificates are short-lived; timestamping is `http://timestamp.acs.microsoft.com`. Linux/macOS zips stay unsigned.
 
 ### Linux / macOS desktop helpers (Inspector zips)
 


### PR DESCRIPTION
## Why
Windows release zips/MSI were unsigned. Azure Artifact Signing account `TitaniumSigning` / profile `titanium-public` is Active.

## What
- `release.yml`: OIDC `azure/login` on `win-x64` (environment `signing`), then sign before zip / after MSI
- Composite `.github/actions/azure-artifact-sign` (SHA256 + ACS timestamp)
- CLI `win-x64` publishes on `windows-latest` (signing action is Windows-only)
- `PACKAGING.md` notes Authenticode is now on the release pipeline

## Secrets (already set)
`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_SIGNING_ENDPOINT`, `AZURE_SIGNING_ACCOUNT`, `AZURE_SIGNING_PROFILE`

Does not cut a release. First signed binaries ship on the next `release.yml` run (tag or workflow_dispatch).