### PR TITLE
feat(packaging): install trust formats (DMG, AppImage, deb/rpm, GPG, Flathub, Homebrew)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,11 +193,65 @@ jobs:
             Push-Location $out
             try { zip -r "../../../Titanium.Cli-$rid.zip" . } finally { Pop-Location }
           }
+      - name: Sign and notarize CLI (macOS)
+        if: startsWith(matrix.rid, 'osx-')
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_CERTIFICATE_P12:-}" ]]; then
+            echo "Apple secrets not set — skipping macOS CLI notarize"
+            exit 0
+          fi
+          chmod +x tools/packaging/osx/sign-and-notarize.sh
+          # Sign main binaries inside the publish dir, then re-zip
+          rid="${{ matrix.rid }}"
+          out="artifacts/cli/$rid"
+          chmod +x "$out/titanium" "$out/twp" 2>/dev/null || true
+          ./tools/packaging/osx/sign-and-notarize.sh "$out/titanium" tools/packaging/osx/TitaniumCli.entitlements
+          ./tools/packaging/osx/sign-and-notarize.sh "$out/twp" tools/packaging/osx/TitaniumCli.entitlements || true
+          rm -f "Titanium.Cli-$rid.zip"
+          (cd "$out" && zip -r "../../../Titanium.Cli-$rid.zip" .)
+          ./tools/packaging/osx/sign-and-notarize.sh "Titanium.Cli-$rid.zip" || true
+      - name: Linux packages (AppImage + deb/rpm)
+        if: matrix.rid == 'linux-x64' || matrix.rid == 'linux-arm64'
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          rid="${{ matrix.rid }}"
+          ver="${RELEASE_VERSION%%-*}"
+          arch=x86_64
+          [[ "$rid" == *arm64* ]] && arch=aarch64
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq rsync imagemagick ruby ruby-dev build-essential rpm || true
+          sudo gem install --no-document fpm || true
+          chmod +x tools/packaging/linux/build-appimage.sh tools/packaging/linux/build-deb-rpm.sh
+          ./tools/packaging/linux/build-appimage.sh cli "artifacts/cli/$rid" \
+            "Titanium.Cli-$rid.AppImage" "$ver" "$arch" || echo "AppImage build soft-failed"
+          ./tools/packaging/linux/build-deb-rpm.sh cli "artifacts/cli/$rid" . "$ver" "$rid" || echo "deb/rpm soft-failed"
+      - name: Stage CLI artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          rid="${{ matrix.rid }}"
+          mkdir -p "staged-cli-$rid"
+          cp "Titanium.Cli-$rid.zip" "staged-cli-$rid/"
+          for ext in AppImage deb rpm; do
+            f="Titanium.Cli-$rid.$ext"
+            [[ -f "$f" ]] && cp "$f" "staged-cli-$rid/" || true
+          done
+          ls -la "staged-cli-$rid"
       - uses: actions/upload-artifact@v4
         with:
           name: cli-${{ matrix.rid }}
-          path: Titanium.Cli-${{ matrix.rid }}.zip
-
+          path: staged-cli-${{ matrix.rid }}/
+          if-no-files-found: error
   build-plus:
     needs: [resolve-version, test]
     runs-on: ubuntu-latest
@@ -333,17 +387,71 @@ jobs:
           certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
           description: Titanium Inspector
           files: ${{ github.workspace }}\TitaniumInspector-win-x64.msi
+      - name: Build / sign / notarize Inspector DMG (macOS)
+        if: startsWith(matrix.rid, 'osx-')
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          rid="${{ matrix.rid }}"
+          ver="${RELEASE_VERSION%%-*}"
+          chmod +x tools/packaging/osx/build-app-bundle.sh \
+            tools/packaging/osx/build-dmg.sh \
+            tools/packaging/osx/sign-and-notarize.sh
+          ./tools/packaging/osx/build-app-bundle.sh \
+            "artifacts/inspector/$rid" "TitaniumInspector.app" "$ver"
+          if [[ -n "${APPLE_CERTIFICATE_P12:-}" ]]; then
+            ./tools/packaging/osx/sign-and-notarize.sh \
+              TitaniumInspector.app tools/packaging/osx/TitaniumInspector.entitlements
+          else
+            echo "Apple secrets not set — building unsigned DMG for CI artifact shape"
+          fi
+          ./tools/packaging/osx/build-dmg.sh \
+            TitaniumInspector.app "TitaniumInspector-$rid.dmg" "Titanium Inspector"
+          if [[ -n "${APPLE_CERTIFICATE_P12:-}" ]]; then
+            ./tools/packaging/osx/sign-and-notarize.sh "TitaniumInspector-$rid.dmg" || true
+          fi
+      - name: Linux packages (AppImage + deb/rpm)
+        if: matrix.rid == 'linux-x64' || matrix.rid == 'linux-arm64'
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          rid="${{ matrix.rid }}"
+          ver="${RELEASE_VERSION%%-*}"
+          arch=x86_64
+          [[ "$rid" == *arm64* ]] && arch=aarch64
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq rsync imagemagick ruby ruby-dev build-essential rpm || true
+          sudo gem install --no-document fpm || true
+          chmod +x tools/packaging/linux/build-appimage.sh tools/packaging/linux/build-deb-rpm.sh
+          ./tools/packaging/linux/build-appimage.sh inspector "artifacts/inspector/$rid" \
+            "TitaniumInspector-$rid.AppImage" "$ver" "$arch" || echo "AppImage build soft-failed"
+          ./tools/packaging/linux/build-deb-rpm.sh inspector "artifacts/inspector/$rid" . "$ver" "$rid" \
+            || echo "deb/rpm soft-failed"
+      - name: Stage Inspector artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          rid="${{ matrix.rid }}"
+          mkdir -p "staged-inspector-$rid"
+          cp "TitaniumInspector-$rid.zip" "staged-inspector-$rid/"
+          for ext in msi AppImage deb rpm dmg; do
+            f="TitaniumInspector-$rid.$ext"
+            [[ -f "$f" ]] && cp "$f" "staged-inspector-$rid/" || true
+          done
+          ls -la "staged-inspector-$rid"
       - uses: actions/upload-artifact@v4
         with:
           name: inspector-${{ matrix.rid }}
           if-no-files-found: error
-          path: |
-            TitaniumInspector-${{ matrix.rid }}.zip
-      - uses: actions/upload-artifact@v4
-        if: matrix.msi
-        with:
-          name: inspector-${{ matrix.rid }}-msi
-          path: TitaniumInspector-${{ matrix.rid }}.msi
+          path: staged-inspector-${{ matrix.rid }}/
 
   smoke-http3:
     needs: build-cli
@@ -409,6 +517,8 @@ jobs:
           RELEASE_TAG: ${{ needs.resolve-version.outputs.release_tag }}
           RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
           RELEASE_CHANNEL: ${{ needs.resolve-version.outputs.channel }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -euo pipefail
           TAG="$RELEASE_TAG"
@@ -416,7 +526,10 @@ jobs:
           CHANNEL="$RELEASE_CHANNEL"
           export RELEASE_TAG VERSION
           mkdir -p dist
-          find artifacts -type f \( -name '*.zip' -o -name '*.dll' -o -name '*.msi' \) -exec cp {} dist/ \;
+          find artifacts -type f \( \
+            -name '*.zip' -o -name '*.dll' -o -name '*.msi' \
+            -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' \
+          \) -exec cp {} dist/ \;
           python3 - <<'PY'
           import hashlib, json, os, pathlib, datetime
           tag = os.environ["RELEASE_TAG"]
@@ -429,7 +542,8 @@ jobs:
             return h.hexdigest()
           assets = {}
           for p in dist.iterdir():
-            assets[p.name] = {"path": str(p), "sha256": sha(p)}
+            if p.is_file():
+              assets[p.name] = {"path": str(p), "sha256": sha(p)}
           manifest = {
             "version": version,
             "channel": channel,
@@ -446,22 +560,37 @@ jobs:
               "Titanium.Web.Proxy.Configuration": version.split("-")[0],
             },
           }
+          def put(product, key, entry):
+            manifest["products"][product]["assets"][key] = entry
           for name, meta in assets.items():
             url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/download/{tag}/{name}"
             entry = {"url": url, "sha256": meta["sha256"]}
             if name.startswith("Titanium.Cli-"):
-              rid = name.removeprefix("Titanium.Cli-").removesuffix(".zip")
-              manifest["products"]["cli"]["assets"][rid] = entry
-            elif name.startswith("TitaniumInspector-") and name.endswith(".msi"):
-              manifest["products"]["inspector"]["assets"]["win-x64-msi"] = entry
+              stem = name.removeprefix("Titanium.Cli-")
+              for ext in (".zip", ".AppImage", ".deb", ".rpm"):
+                if stem.endswith(ext):
+                  rid = stem[: -len(ext)]
+                  key = rid if ext == ".zip" else f"{rid}{ext}"
+                  put("cli", key, entry)
+                  break
             elif name.startswith("TitaniumInspector-"):
-              rid = name.removeprefix("TitaniumInspector-").removesuffix(".zip")
-              manifest["products"]["inspector"]["assets"][rid] = entry
+              stem = name.removeprefix("TitaniumInspector-")
+              if stem.endswith(".msi"):
+                put("inspector", "win-x64-msi", entry)
+              else:
+                for ext in (".zip", ".AppImage", ".deb", ".rpm", ".dmg"):
+                  if stem.endswith(ext):
+                    rid = stem[: -len(ext)]
+                    key = rid if ext == ".zip" else f"{rid}{ext}"
+                    put("inspector", key, entry)
+                    break
             elif name.startswith("Titanium.Plus"):
               manifest["products"]["plus"]["asset"] = entry
           pathlib.Path("dist/release-manifest.json").write_text(json.dumps(manifest, indent=2))
           print(json.dumps(manifest, indent=2))
           PY
+          chmod +x tools/packaging/sign-checksums.sh
+          ./tools/packaging/sign-checksums.sh dist
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -f -a "$TAG" -m "$TAG" "$GITHUB_SHA"

--- a/tools/packaging/GPG_SECRETS.md
+++ b/tools/packaging/GPG_SECRETS.md
@@ -1,0 +1,18 @@
+# GPG release checksums
+
+`release.yml` always attaches `SHA256SUMS`. When the following secrets are set, it also attaches armored signatures:
+
+| Secret | Purpose |
+| --- | --- |
+| `GPG_PRIVATE_KEY` | ASCII-armored private key (or `gpg --export-secret-keys --armor`) |
+| `GPG_PASSPHRASE` | Optional passphrase for the key |
+
+Generate once (example):
+
+```shell
+gpg --batch --passphrase '' --quick-generate-key 'Titanium Releases <you@example.com>' default default 2y
+gpg --export-secret-keys --armor 'Titanium Releases' | gh secret set GPG_PRIVATE_KEY
+gpg --export --armor 'Titanium Releases' > titanium-releases.asc   # publish this public key on the website/docs
+```
+
+Do not paste private keys into chat.

--- a/tools/packaging/PACKAGING.md
+++ b/tools/packaging/PACKAGING.md
@@ -2,12 +2,14 @@
 
 ## RID matrix (7.0)
 
-| Product | RIDs | Notes |
-| --- | --- | --- |
-| CLI | `win-x64`, `linux-x64`, `linux-arm64`, `linux-musl-x64`, `linux-musl-arm64`, `osx-x64`, `osx-arm64` | Self-contained zips |
-| Inspector | Same RIDs | Zip for all; **MSI only** for `win-x64` |
+| Product | RIDs | Primary formats | Also attached |
+| --- | --- | --- | --- |
+| CLI | `win-x64`, `linux-x64`, `linux-arm64`, `linux-musl-*`, `osx-*` | win zip; linux glibc AppImage+deb+rpm; musl zip; osx zip (+ Homebrew) | All RIDs keep a **zip** for `titanium update` |
+| Inspector | Same RIDs | win **MSI**; osx **DMG**; linux glibc AppImage+deb+rpm; musl zip | Zip for all RIDs |
 
-HTTP/3 natives are bundled into every Linux/macOS zip via [`bundle-http3-native.ps1`](bundle-http3-native.ps1) + [`http3-native.lock.json`](http3-native.lock.json). Windows uses OS MsQuic (Win11 / Server 2022+).
+HTTP/3 natives are bundled into every Linux/macOS publish via [`bundle-http3-native.ps1`](bundle-http3-native.ps1) + [`http3-native.lock.json`](http3-native.lock.json). Windows uses OS MsQuic (Win11 / Server 2022+).
+
+Website [download](../../website/download.md) prefers MSI/DMG/AppImage/deb/rpm and hides redundant zips when those exist.
 
 ## Publish (local)
 
@@ -33,15 +35,50 @@ pwsh ./tools/packaging/bundle-http3-native.ps1 -Rid $rid -PublishDir artifacts/i
   -Version 7.0.0
 ```
 
-Uses WiX 5 (`dotnet tool` manifest under `tools/packaging/wix/`) plus **WixToolset.UI.wixext** / **Util** for:
+Uses WiX 5 (`dotnet tool` manifest under `tools/packaging/wix/`) plus **WixToolset.UI.wixext** / **Util**.
 
-- `WixUI_InstallDir` wizard (welcome → license → **install folder** → progress → **Finished**)
-- `ARPPRODUCTICON` (Programs and Features icon from `app.ico`)
-- Start Menu + Desktop shortcuts
-- **Launch Titanium Inspector** checkbox on the exit dialog (first install and upgrades)
-- `CloseApplication` for `TitaniumInspector.exe` so manual MSI upgrades can close a running instance
+### Windows Authenticode
 
-Windows Authenticode uses [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart) in [`release.yml`](../../.github/workflows/release.yml) (`win-x64` CLI `titanium.exe`/`twp.exe`, `TitaniumInspector.exe`, and the MSI). Publisher is the validated individual identity (currently `CN=Jehonathan Thomas`). Leaf certificates are short-lived; timestamping is `http://timestamp.acs.microsoft.com`. Linux/macOS zips stay unsigned.
+Uses [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart) in [`release.yml`](../../.github/workflows/release.yml) (`win-x64` CLI `titanium.exe`/`twp.exe`, `TitaniumInspector.exe`, and the MSI). Publisher is the validated individual identity (currently `CN=Jehonathan Thomas`). Leaf certificates are short-lived; timestamping is `http://timestamp.acs.microsoft.com`.
+
+### macOS codesign + notarize + DMG
+
+Scripts under [`osx/`](osx/):
+
+| Script | Role |
+| --- | --- |
+| `build-app-bundle.sh` | `.app` from Inspector publish folder |
+| `build-dmg.sh` | UDZO DMG with Applications symlink |
+| `sign-and-notarize.sh` | Developer ID codesign + `notarytool` + staple |
+| `TitaniumInspector.entitlements` / `TitaniumCli.entitlements` | Hardened runtime (JIT + network) |
+
+CI is **gated**: if `APPLE_CERTIFICATE_P12` (and related secrets) are unset, macOS jobs still build an **unsigned** DMG for artifact shape; notarize is skipped. Required GitHub secrets: `APPLE_DEVELOPER_ID`, `APPLE_CERTIFICATE_P12` (base64), `APPLE_CERTIFICATE_PASSWORD`, `NOTARY_KEY`, `NOTARY_KEY_ID`, `NOTARY_ISSUER`.
+
+### Linux AppImage / deb / rpm
+
+| Script | Role |
+| --- | --- |
+| [`linux/build-appimage.sh`](linux/build-appimage.sh) | AppImage for `cli` or `inspector` (glibc `linux-x64` / `linux-arm64`) |
+| [`linux/build-deb-rpm.sh`](linux/build-deb-rpm.sh) | `.deb` + `.rpm` via `fpm` (deb fallback without fpm) |
+
+Release asset names match the website loader: `Titanium.Cli-{rid}.{AppImage,deb,rpm}`, `TitaniumInspector-{rid}.{AppImage,deb,rpm,dmg}`.
+
+### GPG checksums
+
+[`sign-checksums.sh`](sign-checksums.sh) writes `SHA256SUMS` (always) and `SHA256SUMS.asc` / `release-manifest.json.asc` when `GPG_PRIVATE_KEY` (+ optional `GPG_PASSPHRASE`) is set in the release job.
+
+### Homebrew (Mac CLI)
+
+Formula source of truth: [`homebrew/titanium.rb`](homebrew/titanium.rb). After a release, run [`homebrew/bump-formula-shas.sh`](homebrew/bump-formula-shas.sh) and push to the `justcoding121/homebrew-titanium` tap (`Formula/titanium.rb`).
+
+```shell
+brew tap justcoding121/titanium
+brew install titanium
+```
+
+### Flathub
+
+Manifests + metainfo under [`flatpak/`](flatpak/). See [`flatpak/README.md`](flatpak/README.md) for first listing and `x-checker-data` updates.
 
 ### Linux / macOS desktop helpers (Inspector zips)
 
@@ -52,16 +89,14 @@ Release publish copies helpers into each Inspector zip:
 | `linux-*` | `install.sh`, `uninstall.sh`, `TitaniumInspector.desktop.in`, `app.ico` |
 | `osx-*` | `install-app.sh`, `uninstall-app.sh`, `app.ico` |
 
-**Linux:** extract the zip, then `./install.sh` (default prefix `~/.local`) to copy the app under `~/.local/share/TitaniumInspector`, add a desktop entry, and symlink `titanium-inspector` on `PATH`. Uninstall: `./uninstall.sh` or `~/.local/share/TitaniumInspector/uninstall.sh`. Portable use without install: run `./TitaniumInspector` from the extracted folder.
-
-**macOS:** extract the zip, then `./install-app.sh` to create `~/Applications/Titanium Inspector.app`. Uninstall: `./uninstall-app.sh`. Portable use: run `./TitaniumInspector` from the extracted folder.
+**Linux:** extract the zip, then `./install.sh` (default prefix `~/.local`). **macOS:** extract, then `./install-app.sh` → `~/Applications/Titanium Inspector.app` (prefer DMG when published).
 
 Winget package IDs:
 
 - `justcoding121.TitaniumInspector` (prefer MSI when attached to the Release)
 - `justcoding121.TitaniumCli` (portable zip)
 
-Manifest stubs live in `tools/packaging/winget/`.
+Manifest stubs live in `tools/packaging/winget/`. Resubmit to `microsoft/winget-pkgs` only after the **first signed stable** with fresh SHA256s (do not resubmit unsigned `7.0.4`).
 
 ## HTTP/3 native lock file
 
@@ -83,9 +118,8 @@ Do **not** mix glibc `.so` into musl zips (or the reverse). Do **not** redistrib
 
 See [`.github/workflows/release.yml`](../../.github/workflows/release.yml):
 
-- Matrix RID × runner (`ubuntu-latest` for win/linux/musl; `macos-latest` for osx).
-- `setup-dotnet` with `cache: true`.
-- Native download cache keyed on lock file hash.
+- Matrix RID × runner (`windows-latest` for `win-x64` CLI/Inspector; `ubuntu-latest` for linux/musl; `macos-latest` for osx).
+- Azure Artifact Signing on Windows; optional Apple notarize when secrets exist; optional GPG on checksums.
 - Smoke: `linux-x64` on host + `linux-musl-x64` inside `alpine:3.24` — `titanium http3-deps status` + assert natives present.
 
 Native bundling runs on **release** only (not every PR).
@@ -98,19 +132,3 @@ Bundling OpenSSL/MsQuic means **this repo owns CVE patching** for those versions
 2. Recompute SHA256 for each URL.
 3. Run a release (or local publish + smoke) for `linux-x64` and `linux-musl-x64`.
 4. Ship a new GitHub Release so operators pick up patched natives.
-
-Target cadence: **at least quarterly**, and immediately for critical OpenSSL/MsQuic CVEs.
-
-## Fallback for edge hosts
-
-```bash
-titanium http3-deps status
-titanium http3-deps install   # apt / dnf / zypper / apk / brew
-```
-
-Not run automatically by MSI/winget. NuGet library consumers stay docs-only (system MsQuic).
-
-## Operator docs
-
-- Website: `/docs/http3`, `/docs/install`, download page RID table
-- Wiki: `HTTP-3.md` packaging sections

--- a/tools/packaging/WINGET_FOLLOWUP.md
+++ b/tools/packaging/WINGET_FOLLOWUP.md
@@ -1,0 +1,14 @@
+# Winget follow-up
+
+Status (2026-09-02): `winget search justcoding121.TitaniumCli` / Inspector — **not in catalog**. Prior `microsoft/winget-pkgs` PRs for unsigned `7.0.4` were closed by the MS bot and never landed on master.
+
+## Do not
+
+- Resubmit another unsigned `7.0.4` with the same installer SHA256s.
+
+## After first signed stable (`7.0.5+` recommended if binaries change)
+
+1. Merge repo stub so `twp` → `twp.exe` ([`TitaniumCli.yaml`](winget/TitaniumCli.yaml)).
+2. Compute new SHA256 for `Titanium.Cli-win-x64.zip` and `TitaniumInspector-win-x64.msi` (+ zip if submitted).
+3. Open fresh PRs against `microsoft/winget-pkgs` using the stubs under [`winget/`](winget/).
+4. Note Authenticode publisher **Jehonathan Thomas** in PR description if SmartScreen/winget validation asks.

--- a/tools/packaging/flatpak/README.md
+++ b/tools/packaging/flatpak/README.md
@@ -1,0 +1,40 @@
+# Flathub packaging (Titanium Inspector + CLI)
+
+First listing is a **human Flathub review**. Later stables should be version / URL / SHA bumps only.
+
+## App IDs
+
+| App | Flatpak ID | Manifest |
+| --- | --- | --- |
+| Inspector | `io.github.justcoding121.TitaniumInspector` | [`io.github.justcoding121.TitaniumInspector.yml`](io.github.justcoding121.TitaniumInspector.yml) |
+| CLI | `io.github.justcoding121.TitaniumCli` | [`io.github.justcoding121.TitaniumCli.yml`](io.github.justcoding121.TitaniumCli.yml) |
+
+## First submission checklist
+
+1. Cut a **signed/stable** GitHub Release that includes `TitaniumInspector-linux-x64.zip` and `Titanium.Cli-linux-x64.zip`.
+2. Fill `sha256:` in both manifests (`REPLACE_AFTER_RELEASE` → real digest). Prefer AppImage source later if Flathub reviewers prefer a single file; zip is fine for first listing.
+3. Create Flathub account + two new app repos (or one PR per app) under [flathub/flathub](https://github.com/flathub/flathub) following [App Submission](https://docs.flathub.org/docs/for-app-authors/submission).
+4. Copy this directory’s manifests, `.desktop`, and `.metainfo.xml` into each Flathub app repo.
+5. Respond to reviewer sandbox / metainfo feedback (network + display sockets are already declared for Inspector).
+
+## Later versions (`flathub-updates`)
+
+Manifests include `x-checker-data` so [flathub-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) can open PRs when GitHub Releases change.
+
+After each stable cut you can also bump manually:
+
+```shell
+# Example: recompute sha of the linux-x64 zip used by the manifest
+sha256sum TitaniumInspector-linux-x64.zip
+# Edit url tag + sha256 in the Flathub app repo; open PR
+```
+
+Optional CI in this monorepo: add a workflow that opens a PR against the Flathub app repos with updated URL/SHA — keep secrets for a bot token with access to those forks.
+
+## Local build smoke
+
+```shell
+flatpak-builder --user --install --force-clean /tmp/ti-build \
+  tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+flatpak run io.github.justcoding121.TitaniumInspector
+```

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.metainfo.xml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.metainfo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.github.justcoding121.TitaniumCli</id>
+  <name>Titanium CLI</name>
+  <summary>Titanium Web Proxy command-line interface</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer_name>Jehonathan Thomas</developer_name>
+  <url type="homepage">https://github.com/justcoding121/titanium-web-proxy</url>
+  <description>
+    <p>Command-line interface for Titanium Web Proxy (titanium / twp).</p>
+  </description>
+  <provides>
+    <binary>titanium</binary>
+    <binary>twp</binary>
+  </provides>
+  <releases>
+    <release version="7.0.4" date="2026-09-01"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
@@ -1,0 +1,31 @@
+# Flatpak manifest — Titanium CLI (first listing).
+# App ID: io.github.justcoding121.TitaniumCli
+
+id: io.github.justcoding121.TitaniumCli
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: titanium
+finish-args:
+  - --share=network
+  - --filesystem=home
+modules:
+  - name: titanium-cli
+    buildsystem: simple
+    build-commands:
+      - install -d /app/bin
+      - cp -a payload/. /app/bin/
+      - chmod +x /app/bin/titanium /app/bin/twp || true
+      - install -Dm644 io.github.justcoding121.TitaniumCli.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumCli.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/Titanium.Cli-linux-x64.zip
+        sha256: REPLACE_AFTER_RELEASE
+        dest: payload
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/justcoding121/titanium-web-proxy/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: (.assets[] | select(.name == "Titanium.Cli-linux-x64.zip") | .browser_download_url)
+      - type: file
+        path: io.github.justcoding121.TitaniumCli.metainfo.xml

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.desktop
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Titanium Inspector
+Comment=Desktop MITM traffic debugger
+Exec=TitaniumInspector
+Icon=io.github.justcoding121.TitaniumInspector
+Terminal=false
+Categories=Development;Network;
+StartupNotify=true

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.metainfo.xml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.metainfo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.justcoding121.TitaniumInspector</id>
+  <name>Titanium Inspector</name>
+  <summary>Desktop MITM traffic debugger</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>PolyForm-Noncommercial-1.0.0</project_license>
+  <developer_name>Jehonathan Thomas</developer_name>
+  <url type="homepage">https://github.com/justcoding121/titanium-web-proxy</url>
+  <description>
+    <p>Titanium Inspector is a desktop MITM debugger built on Titanium Web Proxy.</p>
+  </description>
+  <launchable type="desktop-id">io.github.justcoding121.TitaniumInspector.desktop</launchable>
+  <releases>
+    <release version="7.0.4" date="2026-09-01"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
@@ -1,0 +1,45 @@
+# Flatpak manifest — Titanium Inspector (first listing).
+# App ID: io.github.justcoding121.TitaniumInspector
+# Submit to Flathub as a new app repo; later versions bump url + sha256 only.
+#
+# Build locally:
+#   flatpak-builder --user --install --force-clean build-dir \
+#     tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+
+id: io.github.justcoding121.TitaniumInspector
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: TitaniumInspector
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --filesystem=home
+  - --filesystem=xdg-download
+modules:
+  - name: titanium-inspector
+    buildsystem: simple
+    build-commands:
+      - install -d /app/bin
+      - cp -a payload/. /app/bin/
+      - chmod +x /app/bin/TitaniumInspector
+      - install -Dm644 io.github.justcoding121.TitaniumInspector.desktop /app/share/applications/io.github.justcoding121.TitaniumInspector.desktop
+      - install -Dm644 io.github.justcoding121.TitaniumInspector.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumInspector.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-linux-x64.zip
+        sha256: REPLACE_AFTER_RELEASE
+        dest: payload
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/justcoding121/titanium-web-proxy/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: (.assets[] | select(.name == "TitaniumInspector-linux-x64.zip") | .browser_download_url)
+      - type: file
+        path: io.github.justcoding121.TitaniumInspector.desktop
+      - type: file
+        path: io.github.justcoding121.TitaniumInspector.metainfo.xml

--- a/tools/packaging/homebrew/bump-formula-shas.sh
+++ b/tools/packaging/homebrew/bump-formula-shas.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Print Homebrew formula snippet with SHA256s from a release-manifest or zip paths.
+# Usage: ./bump-formula-shas.sh <version> <osx-arm64.zip> <osx-x64.zip>
+set -euo pipefail
+VERSION="${1:?version}"
+ARM_ZIP="${2:?osx-arm64 zip}"
+X64_ZIP="${3:?osx-x64 zip}"
+ARM_SHA="$(shasum -a 256 "${ARM_ZIP}" | awk '{print $1}')"
+X64_SHA="$(shasum -a 256 "${X64_ZIP}" | awk '{print $1}')"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+sed -e "s/version \".*\"/version \"${VERSION}\"/" \
+    -e "s/REPLACE_OSX_ARM64_SHA256/${ARM_SHA}/" \
+    -e "s/REPLACE_OSX_X64_SHA256/${X64_SHA}/" \
+    "${ROOT}/titanium.rb"

--- a/tools/packaging/homebrew/titanium.rb
+++ b/tools/packaging/homebrew/titanium.rb
@@ -1,0 +1,37 @@
+# Homebrew formula template for Titanium CLI (custom tap).
+# After each release, bump url + sha256 for the active macOS arch zip.
+# Tap usage:
+#   brew tap justcoding121/titanium
+#   brew install titanium
+#
+# Place this file in a homebrew-titanium tap repo as Formula/titanium.rb
+# (kept here as the source of truth for CI bump scripts).
+
+class Titanium < Formula
+  desc "Titanium Web Proxy CLI (MITM / reverse proxy)"
+  homepage "https://github.com/justcoding121/titanium-web-proxy"
+  version "7.0.4"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/justcoding121/titanium-web-proxy/releases/download/v#{version}/Titanium.Cli-osx-arm64.zip"
+      sha256 "REPLACE_OSX_ARM64_SHA256"
+    end
+    on_intel do
+      url "https://github.com/justcoding121/titanium-web-proxy/releases/download/v#{version}/Titanium.Cli-osx-x64.zip"
+      sha256 "REPLACE_OSX_X64_SHA256"
+    end
+  end
+
+  def install
+    # Keep publish layout so @loader_path / $ORIGIN natives resolve next to the binary.
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"titanium"
+    bin.install_symlink libexec/"twp" if (libexec/"twp").exist?
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/titanium version")
+  end
+end

--- a/tools/packaging/linux/build-appimage.sh
+++ b/tools/packaging/linux/build-appimage.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Wrap a self-contained publish directory as an AppImage (glibc linux-x64 / linux-arm64).
+set -euo pipefail
+
+PRODUCT="${1:?cli|inspector}"
+PAYLOAD_DIR="${2:?payload dir}"
+OUT_APPIMAGE="${3:?output .AppImage path}"
+VERSION="${4:-0.0.0}"
+ARCH_HINT="${5:-x86_64}" # x86_64 | aarch64
+
+PAYLOAD_DIR="$(cd "${PAYLOAD_DIR}" && pwd)"
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+case "${PRODUCT}" in
+  cli)
+    EXE_NAME="titanium"
+    DESKTOP_NAME="Titanium CLI"
+    ICON_ID="titanium-cli"
+    ;;
+  inspector)
+    EXE_NAME="TitaniumInspector"
+    DESKTOP_NAME="Titanium Inspector"
+    ICON_ID="titanium-inspector"
+    ;;
+  *)
+    echo "error: product must be cli or inspector" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "${PAYLOAD_DIR}/${EXE_NAME}" && ! -f "${PAYLOAD_DIR}/${EXE_NAME}.exe" ]]; then
+  echo "error: ${EXE_NAME} missing under ${PAYLOAD_DIR}" >&2
+  exit 1
+fi
+
+APPDIR="${WORK}/AppDir"
+mkdir -p "${APPDIR}/usr/bin" "${APPDIR}/usr/share/applications" "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+
+# Copy entire payload beside the binary so natives resolve via $ORIGIN.
+rsync -a "${PAYLOAD_DIR}/" "${APPDIR}/usr/bin/"
+chmod +x "${APPDIR}/usr/bin/${EXE_NAME}" 2>/dev/null || true
+# AppImage entry must be AppRun
+cat > "${APPDIR}/AppRun" <<EOF
+#!/bin/sh
+HERE="\$(dirname "\$(readlink -f "\$0")")"
+exec "\${HERE}/usr/bin/${EXE_NAME}" "\$@"
+EOF
+chmod +x "${APPDIR}/AppRun"
+
+# Desktop entry
+cat > "${APPDIR}/usr/share/applications/${ICON_ID}.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=${DESKTOP_NAME}
+Exec=${EXE_NAME}
+Icon=${ICON_ID}
+Categories=Development;Network;
+Terminal=$([ "${PRODUCT}" = "cli" ] && echo true || echo false)
+EOF
+cp "${APPDIR}/usr/share/applications/${ICON_ID}.desktop" "${APPDIR}/${ICON_ID}.desktop"
+
+# Icon (best-effort from app.ico)
+ICON_SRC=""
+for c in "${PAYLOAD_DIR}/app.ico" "${ROOT}/src/Titanium.Inspector/Assets/app.ico"; do
+  [[ -f "$c" ]] && ICON_SRC="$c" && break
+done
+if [[ -n "${ICON_SRC}" ]] && command -v convert >/dev/null 2>&1; then
+  convert "${ICON_SRC}" -resize 256x256 "${APPDIR}/usr/share/icons/hicolor/256x256/apps/${ICON_ID}.png" || true
+  cp -f "${APPDIR}/usr/share/icons/hicolor/256x256/apps/${ICON_ID}.png" "${APPDIR}/${ICON_ID}.png" 2>/dev/null || true
+elif [[ -n "${ICON_SRC}" ]]; then
+  # Fallback: leave no png; appimagetool still works
+  :
+fi
+
+# Fetch appimagetool
+TOOL_ARCH="${ARCH_HINT}"
+TOOL_URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${TOOL_ARCH}.AppImage"
+TOOL="${WORK}/appimagetool.AppImage"
+curl -fsSL "${TOOL_URL}" -o "${TOOL}"
+chmod +x "${TOOL}"
+
+export ARCH="${ARCH_HINT}"
+export VERSION
+# Extract tool if FUSE unavailable (common on GHA)
+if ! "${TOOL}" --appimage-extract-and-run --version >/dev/null 2>&1; then
+  cd "${WORK}"
+  "${TOOL}" --appimage-extract >/dev/null
+  TOOL="${WORK}/squashfs-root/AppRun"
+fi
+
+OUT_DIR="$(cd "$(dirname "${OUT_APPIMAGE}")" && pwd)"
+OUT_LEAF="$(basename "${OUT_APPIMAGE}")"
+cd "${WORK}"
+"${TOOL}" --appimage-extract-and-run "${APPDIR}" "${OUT_DIR}/${OUT_LEAF}" 2>/dev/null \
+  || "${TOOL}" "${APPDIR}" "${OUT_DIR}/${OUT_LEAF}"
+
+echo "Built ${OUT_APPIMAGE}"

--- a/tools/packaging/linux/build-deb-rpm.sh
+++ b/tools/packaging/linux/build-deb-rpm.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Build .deb and .rpm from a self-contained publish folder (glibc linux-x64 / linux-arm64).
+# Uses fpm when available; falls back to a minimal dpkg-deb for .deb only.
+set -euo pipefail
+
+PRODUCT="${1:?cli|inspector}"
+PAYLOAD_DIR="${2:?payload dir}"
+OUT_DIR="${3:?output directory}"
+VERSION="${4:-0.0.0}"
+RID="${5:-linux-x64}" # linux-x64 | linux-arm64
+
+PAYLOAD_DIR="$(cd "${PAYLOAD_DIR}" && pwd)"
+OUT_DIR="$(mkdir -p "${OUT_DIR}" && cd "${OUT_DIR}" && pwd)"
+VERSION="${VERSION%%-*}"
+
+case "${RID}" in
+  *arm64*) DEB_ARCH=arm64; RPM_ARCH=aarch64 ;;
+  *) DEB_ARCH=amd64; RPM_ARCH=x86_64 ;;
+esac
+
+case "${PRODUCT}" in
+  cli)
+    NAME="titanium-cli"
+    EXE="titanium"
+    DESC="Titanium Web Proxy CLI"
+    ;;
+  inspector)
+    NAME="titanium-inspector"
+    EXE="TitaniumInspector"
+    DESC="Titanium Inspector MITM debugger"
+    ;;
+  *)
+    echo "error: product must be cli or inspector" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "${PAYLOAD_DIR}/${EXE}" ]]; then
+  echo "error: ${EXE} missing under ${PAYLOAD_DIR}" >&2
+  exit 1
+fi
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+PREFIX="${STAGE}/opt/${NAME}"
+mkdir -p "${PREFIX}" "${STAGE}/usr/bin"
+rsync -a "${PAYLOAD_DIR}/" "${PREFIX}/"
+chmod +x "${PREFIX}/${EXE}" 2>/dev/null || true
+# PATH symlink
+ln -sf "/opt/${NAME}/${EXE}" "${STAGE}/usr/bin/${EXE}"
+if [[ "${PRODUCT}" == "cli" && -f "${PREFIX}/twp" ]]; then
+  ln -sf "/opt/${NAME}/twp" "${STAGE}/usr/bin/twp"
+fi
+
+if [[ "${PRODUCT}" == "inspector" ]]; then
+  mkdir -p "${STAGE}/usr/share/applications" "${STAGE}/usr/share/icons/hicolor/256x256/apps"
+  DESKTOP_IN="${PAYLOAD_DIR}/TitaniumInspector.desktop.in"
+  if [[ -f "${DESKTOP_IN}" ]]; then
+    sed -e "s|@EXEC@|/opt/${NAME}/${EXE}|g" -e "s|@ICON@|titanium-inspector|g" \
+      "${DESKTOP_IN}" > "${STAGE}/usr/share/applications/titanium-inspector.desktop"
+  fi
+fi
+
+DEB_OUT="${OUT_DIR}/${NAME}_${VERSION}_${DEB_ARCH}.deb"
+RPM_OUT="${OUT_DIR}/${NAME}-${VERSION}-1.${RPM_ARCH}.rpm"
+
+if command -v fpm >/dev/null 2>&1; then
+  fpm -s dir -t deb -n "${NAME}" -v "${VERSION}" -a "${DEB_ARCH}" \
+    --description "${DESC}" --license "PolyForm-Noncommercial-1.0.0" \
+    --url "https://github.com/justcoding121/titanium-web-proxy" \
+    -C "${STAGE}" -p "${DEB_OUT}" \
+    opt usr
+  fpm -s dir -t rpm -n "${NAME}" -v "${VERSION}" -a "${RPM_ARCH}" \
+    --description "${DESC}" --license "PolyForm-Noncommercial-1.0.0" \
+    --url "https://github.com/justcoding121/titanium-web-proxy" \
+    -C "${STAGE}" -p "${RPM_OUT}" \
+    opt usr
+else
+  # Minimal .deb without fpm
+  DEB_ROOT="$(mktemp -d)"
+  mkdir -p "${DEB_ROOT}/DEBIAN"
+  cp -a "${STAGE}/." "${DEB_ROOT}/"
+  cat > "${DEB_ROOT}/DEBIAN/control" <<EOF
+Package: ${NAME}
+Version: ${VERSION}
+Section: devel
+Priority: optional
+Architecture: ${DEB_ARCH}
+Maintainer: Jehonathan Thomas <jehonathan@live.com>
+Description: ${DESC}
+Depends: libnuma1
+EOF
+  dpkg-deb --build "${DEB_ROOT}" "${DEB_OUT}"
+  rm -rf "${DEB_ROOT}"
+  echo "warn: fpm not installed — skipped .rpm (${RPM_OUT})" >&2
+fi
+
+# Rename to release convention used by download.data.ts
+case "${PRODUCT}" in
+  cli)
+    [[ -f "${DEB_OUT}" ]] && cp -f "${DEB_OUT}" "${OUT_DIR}/Titanium.Cli-${RID}.deb"
+    [[ -f "${RPM_OUT}" ]] && cp -f "${RPM_OUT}" "${OUT_DIR}/Titanium.Cli-${RID}.rpm"
+    ;;
+  inspector)
+    [[ -f "${DEB_OUT}" ]] && cp -f "${DEB_OUT}" "${OUT_DIR}/TitaniumInspector-${RID}.deb"
+    [[ -f "${RPM_OUT}" ]] && cp -f "${RPM_OUT}" "${OUT_DIR}/TitaniumInspector-${RID}.rpm"
+    ;;
+esac
+
+echo "Built packages under ${OUT_DIR}"
+ls -la "${OUT_DIR}"/*."${DEB_ARCH}".deb "${OUT_DIR}"/*."${RPM_ARCH}".rpm \
+  "${OUT_DIR}/Titanium."*-"${RID}".deb "${OUT_DIR}/TitaniumInspector-${RID}".* \
+  "${OUT_DIR}/Titanium.Cli-${RID}".* 2>/dev/null || true

--- a/tools/packaging/osx/APPLE_SECRETS.md
+++ b/tools/packaging/osx/APPLE_SECRETS.md
@@ -1,0 +1,28 @@
+# Apple Developer secrets (macOS Gatekeeper)
+
+Agent work (scripts + gated `release.yml`) is ready. **Notarization stays no-op until you finish this checklist** and put secrets in GitHub — do **not** paste `.p12` / `.p8` / private keys into chat.
+
+## A. Developer ID Application certificate
+
+1. [Certificates list](https://developer.apple.com/account/resources/certificates/list) → **+** → **Developer ID Application**.
+2. Create a CSR locally (Keychain on Mac, or `openssl req -new -newkey rsa:2048 -nodes -keyout developer_id.key -out developer_id.csr` on Windows).
+3. Upload CSR → download `.cer` → export password-protected `.p12` (needs the private key from step 2).
+4. Note identity string: `Developer ID Application: Your Name (TEAMID)`.
+
+## B. App Store Connect API key (notarization)
+
+1. [App Store Connect](https://appstoreconnect.apple.com) → Users and Access → Integrations → App Store Connect API.
+2. Create a key; download `.p8` once; copy **Issuer ID** and **Key ID**.
+
+## C. GitHub secrets
+
+| Secret | Value |
+| --- | --- |
+| `APPLE_DEVELOPER_ID` | `Developer ID Application: … (TEAMID)` |
+| `APPLE_CERTIFICATE_P12` | base64 of the `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | p12 password |
+| `NOTARY_KEY` | `.p8` contents |
+| `NOTARY_KEY_ID` | Key ID |
+| `NOTARY_ISSUER` | Issuer ID |
+
+When done, tell the agent: **“Apple secrets are in GitHub”** so a beta release can verify Gatekeeper.

--- a/tools/packaging/osx/TitaniumCli.entitlements
+++ b/tools/packaging/osx/TitaniumCli.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/packaging/osx/TitaniumInspector.entitlements
+++ b/tools/packaging/osx/TitaniumInspector.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Self-contained .NET / Avalonia needs JIT -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<!-- Network client + local proxy / MITM listener -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/packaging/osx/build-app-bundle.sh
+++ b/tools/packaging/osx/build-app-bundle.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Build Titanium Inspector.app from a published self-contained folder (CI).
+set -euo pipefail
+
+PAYLOAD_DIR="${1:?payload dir}"
+APP_PATH="${2:?output .app path}"
+VERSION="${3:-7.0.0}"
+EXE_NAME="TitaniumInspector"
+
+PAYLOAD_DIR="$(cd "$PAYLOAD_DIR" && pwd)"
+if [[ ! -f "${PAYLOAD_DIR}/${EXE_NAME}" ]]; then
+  echo "error: ${EXE_NAME} missing under ${PAYLOAD_DIR}" >&2
+  exit 1
+fi
+
+rm -rf "${APP_PATH}"
+mkdir -p "${APP_PATH}/Contents/MacOS" "${APP_PATH}/Contents/Resources"
+
+# Copy publish output into MacOS (exclude helper scripts).
+rsync -a --exclude 'install-app.sh' --exclude 'uninstall-app.sh' \
+  "${PAYLOAD_DIR}/" "${APP_PATH}/Contents/MacOS/" 2>/dev/null \
+  || {
+    cp -R "${PAYLOAD_DIR}/." "${APP_PATH}/Contents/MacOS/"
+    rm -f "${APP_PATH}/Contents/MacOS/install-app.sh" "${APP_PATH}/Contents/MacOS/uninstall-app.sh"
+  }
+
+chmod +x "${APP_PATH}/Contents/MacOS/${EXE_NAME}"
+
+ICON_SRC=""
+for candidate in "${PAYLOAD_DIR}/app.ico" "${APP_PATH}/Contents/MacOS/app.ico"; do
+  if [[ -f "${candidate}" ]]; then
+    ICON_SRC="${candidate}"
+    break
+  fi
+done
+
+ICON_FILE=""
+if [[ -n "${ICON_SRC}" ]] && command -v sips >/dev/null 2>&1 && command -v iconutil >/dev/null 2>&1; then
+  ICONSET="$(mktemp -d)/AppIcon.iconset"
+  mkdir -p "${ICONSET}"
+  TMP_PNG="$(mktemp).png"
+  if sips -s format png "${ICON_SRC}" --out "${TMP_PNG}" >/dev/null 2>&1; then
+    for size in 16 32 128 256 512; do
+      sips -z "${size}" "${size}" "${TMP_PNG}" --out "${ICONSET}/icon_${size}x${size}.png" >/dev/null
+      double=$((size * 2))
+      sips -z "${double}" "${double}" "${TMP_PNG}" --out "${ICONSET}/icon_${size}x${size}@2x.png" >/dev/null
+    done
+    iconutil -c icns "${ICONSET}" -o "${APP_PATH}/Contents/Resources/AppIcon.icns"
+    ICON_FILE="AppIcon.icns"
+  fi
+  rm -rf "$(dirname "${ICONSET}")" "${TMP_PNG}" 2>/dev/null || true
+fi
+
+cat > "${APP_PATH}/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>${EXE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.justcoding121.TitaniumInspector</string>
+	<key>CFBundleName</key>
+	<string>Titanium Inspector</string>
+	<key>CFBundleDisplayName</key>
+	<string>Titanium Inspector</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>${VERSION}</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+$([ -n "${ICON_FILE}" ] && printf '\t<key>CFBundleIconFile</key>\n\t<string>%s</string>\n' "${ICON_FILE}")
+</dict>
+</plist>
+EOF
+
+echo "Built ${APP_PATH}"

--- a/tools/packaging/osx/build-dmg.sh
+++ b/tools/packaging/osx/build-dmg.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Create a simple drag-to-Applications DMG from a .app bundle.
+set -euo pipefail
+
+APP_PATH="${1:?path to .app}"
+DMG_PATH="${2:?output .dmg path}"
+VOLUME_NAME="${3:-Titanium Inspector}"
+
+APP_PATH="$(cd "$(dirname "${APP_PATH}")" && pwd)/$(basename "${APP_PATH}")"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+
+cp -R "${APP_PATH}" "${STAGE}/"
+ln -s /Applications "${STAGE}/Applications"
+
+# UDZO compressed read-only image
+hdiutil create -volname "${VOLUME_NAME}" -srcfolder "${STAGE}" -ov -format UDZO "${DMG_PATH}"
+echo "Built ${DMG_PATH}"

--- a/tools/packaging/osx/sign-and-notarize.sh
+++ b/tools/packaging/osx/sign-and-notarize.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Codesign + notarize + staple a macOS artifact (.app, .dmg, or .zip).
+# Requires env: APPLE_DEVELOPER_ID, APPLE_CERTIFICATE_P12 (base64), APPLE_CERTIFICATE_PASSWORD,
+#               NOTARY_KEY, NOTARY_KEY_ID, NOTARY_ISSUER
+set -euo pipefail
+
+TARGET="${1:?path to .app / .dmg / .zip}"
+ENTITLEMENTS="${2:-}"
+
+if [[ -z "${APPLE_CERTIFICATE_P12:-}" || -z "${APPLE_DEVELOPER_ID:-}" ]]; then
+  echo "skip: Apple signing secrets not configured"
+  exit 0
+fi
+
+KEYCHAIN="twp-signing.keychain-db"
+KEYCHAIN_PW="$(openssl rand -base64 24)"
+CERT_PATH="$(mktemp).p12"
+trap 'rm -f "${CERT_PATH}"; security delete-keychain "${KEYCHAIN}" 2>/dev/null || true' EXIT
+
+echo "${APPLE_CERTIFICATE_P12}" | base64 --decode > "${CERT_PATH}"
+security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+security set-keychain-settings -lut 21600 "${KEYCHAIN}"
+security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+security import "${CERT_PATH}" -P "${APPLE_CERTIFICATE_PASSWORD}" -A -t cert -f pkcs12 -k "${KEYCHAIN}"
+security list-keychain -d user -s "${KEYCHAIN}" $(security list-keychain -d user | tr -d '"')
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}"
+
+SIGN_ARGS=(--force --options runtime --timestamp --sign "${APPLE_DEVELOPER_ID}")
+if [[ -n "${ENTITLEMENTS}" && -f "${ENTITLEMENTS}" ]]; then
+  SIGN_ARGS+=(--entitlements "${ENTITLEMENTS}")
+fi
+
+if [[ -d "${TARGET}" && "${TARGET}" == *.app ]]; then
+  # Sign nested dylibs/frameworks first, then the app.
+  find "${TARGET}/Contents" -type f \( -name '*.dylib' -o -name '*.so' -o -perm +111 \) 2>/dev/null \
+    | while read -r f; do
+        file -b "${f}" 2>/dev/null | grep -qiE 'Mach-O|library|executable' || continue
+        codesign "${SIGN_ARGS[@]}" "${f}" || true
+      done
+  codesign "${SIGN_ARGS[@]}" --deep "${TARGET}"
+  codesign --verify --verbose=2 "${TARGET}"
+elif [[ -f "${TARGET}" ]]; then
+  codesign "${SIGN_ARGS[@]}" "${TARGET}"
+  codesign --verify --verbose=2 "${TARGET}" || true
+else
+  echo "error: unsupported target ${TARGET}" >&2
+  exit 1
+fi
+
+if [[ -n "${NOTARY_KEY:-}" && -n "${NOTARY_KEY_ID:-}" && -n "${NOTARY_ISSUER:-}" ]]; then
+  KEY_FILE="$(mktemp).p8"
+  printf '%s\n' "${NOTARY_KEY}" > "${KEY_FILE}"
+  SUBMIT="${TARGET}"
+  if [[ -d "${TARGET}" ]]; then
+    SUBMIT="$(mktemp -d)/notarize.zip"
+    ditto -c -k --keepParent "${TARGET}" "${SUBMIT}"
+  fi
+  xcrun notarytool submit "${SUBMIT}" --wait \
+    --key "${KEY_FILE}" --key-id "${NOTARY_KEY_ID}" --issuer "${NOTARY_ISSUER}"
+  rm -f "${KEY_FILE}"
+  if [[ "${TARGET}" == *.dmg || "${TARGET}" == *.app || -d "${TARGET}" ]]; then
+    xcrun stapler staple "${TARGET}" || true
+  fi
+fi
+
+echo "Signed ${TARGET}"

--- a/tools/packaging/sign-checksums.sh
+++ b/tools/packaging/sign-checksums.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# GPG-sign SHA256SUMS (and optional release-manifest.json) when GPG_PRIVATE_KEY is set.
+set -euo pipefail
+
+DIST_DIR="${1:?dist directory}"
+cd "${DIST_DIR}"
+
+# Build checksums for all release artifacts
+: > SHA256SUMS
+for f in *; do
+  [[ -f "$f" ]] || continue
+  [[ "$f" == SHA256SUMS* ]] && continue
+  sha256sum "$f" >> SHA256SUMS
+done
+
+if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
+  echo "warn: GPG_PRIVATE_KEY not set — wrote SHA256SUMS without signature"
+  exit 0
+fi
+
+GNUPGHOME="$(mktemp -d)"
+export GNUPGHOME
+trap 'rm -rf "${GNUPGHOME}"' EXIT
+chmod 700 "${GNUPGHOME}"
+
+printf '%s\n' "${GPG_PRIVATE_KEY}" | gpg --batch --import
+# Optional passphrase via GPG_PASSPHRASE
+ARGS=(--batch --yes --detach-sign --armor)
+if [[ -n "${GPG_PASSPHRASE:-}" ]]; then
+  ARGS+=(--pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}")
+fi
+gpg "${ARGS[@]}" -o SHA256SUMS.asc SHA256SUMS
+if [[ -f release-manifest.json ]]; then
+  gpg "${ARGS[@]}" -o release-manifest.json.asc release-manifest.json
+fi
+echo "Wrote SHA256SUMS and signatures"

--- a/tools/packaging/winget/TitaniumCli.yaml
+++ b/tools/packaging/winget/TitaniumCli.yaml
@@ -1,4 +1,6 @@
 # justcoding121.TitaniumCli
+# Stub for microsoft/winget-pkgs. Resubmit only after a *signed* stable cut with fresh SHA256.
+# Publisher on Authenticode is "Jehonathan Thomas"; winget Publisher field may stay justcoding121.
 PackageIdentifier: justcoding121.TitaniumCli
 PackageVersion: 7.0.4
 PackageLocale: en-US
@@ -13,7 +15,7 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: titanium.exe
         PortableCommandAlias: titanium
-      - RelativeFilePath: titanium.exe
+      - RelativeFilePath: twp.exe
         PortableCommandAlias: twp
     InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/Titanium.Cli-win-x64.zip
     InstallerSha256: 67fe922f04d4fddd08a3d459459efda9601b2e814bcdaa8c2c40858fa2bf841a

--- a/tools/packaging/winget/TitaniumInspector.yaml
+++ b/tools/packaging/winget/TitaniumInspector.yaml
@@ -1,5 +1,6 @@
 # justcoding121.TitaniumInspector
-# Submit a PR to https://github.com/microsoft/winget-pkgs after a GitHub Release with MSI.
+# Submit a PR to https://github.com/microsoft/winget-pkgs after a *signed* GitHub Release with MSI.
+# Authenticode publisher: Jehonathan Thomas. Do not resubmit unsigned 7.0.4 — wait for next signed stable + new SHA256s.
 
 PackageIdentifier: justcoding121.TitaniumInspector
 PackageVersion: 7.0.4

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -2,6 +2,19 @@
 
 Full download buttons live on the [Download](/download) page. This page is the short install guide.
 
+## Trust / publisher
+
+- **Windows:** Signed releases show Authenticode publisher **Jehonathan Thomas** (Azure Artifact Signing). SmartScreen reputation still builds over downloads/time.
+- **macOS:** Prefer the notarized **DMG** for Inspector when published. CLI zips are signed/notarized when Apple Developer secrets are configured in CI.
+- **Linux:** Prefer AppImage / `.deb` / `.rpm` (glibc) or Flathub when listed. Verify GitHub assets with `SHA256SUMS` (+ `SHA256SUMS.asc` when GPG signing is enabled):
+
+```shell
+# From a release asset directory
+sha256sum -c SHA256SUMS
+# Optional, when SHA256SUMS.asc is attached:
+gpg --verify SHA256SUMS.asc SHA256SUMS
+```
+
 ## Library
 
 ```shell
@@ -18,9 +31,16 @@ On Windows, **winget is stable-only**:
 winget install justcoding121.TitaniumCli
 ```
 
-Stable CLI zips are on the [Download](/download) page (`v7.0.4`). For **beta** (or any OS), use the beta section or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*.zip` assets are published (e.g. `v7.0.4-beta`).
+**macOS (Homebrew tap, when published):**
 
-Pick the **matching RID** (e.g. Alpine/K8s → `linux-musl-x64` or `linux-musl-arm64`, not `linux-x64`). HTTP/3 natives ship inside those zips — see [HTTP/3](/docs/http3).
+```shell
+brew tap justcoding121/titanium
+brew install titanium
+```
+
+Stable CLI packages are on the [Download](/download) page (`v7.0.4`). For **beta** (or any OS), use the beta section or [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) when `Titanium.Cli-*` assets are published (e.g. `v7.0.4-beta`).
+
+Pick the **matching RID** (e.g. Alpine/K8s → `linux-musl-x64` or `linux-musl-arm64`, not `linux-x64`). Prefer AppImage / deb / rpm on glibc Linux; musl stays zip-only. HTTP/3 natives ship inside those packages — see [HTTP/3](/docs/http3).
 
 ```shell
 titanium update --channel beta
@@ -28,7 +48,7 @@ titanium version --check --channel beta
 titanium http3-deps status
 ```
 
-`titanium update` checks the selected channel, downloads the RID zip, verifies SHA256, replaces the install directory after the process exits, and prints the new version. Use `--channel stable` (default) or `--channel beta` — it does not pick “whichever is newer” across channels.
+`titanium update` checks the selected channel, downloads the RID **zip**, verifies SHA256, replaces the install directory after the process exits, and prints the new version. Use `--channel stable` (default) or `--channel beta` — it does not pick “whichever is newer” across channels.
 
 ## Plus
 
@@ -46,10 +66,11 @@ Prefer [Download](/download). **winget is stable-only**:
 winget install justcoding121.TitaniumInspector
 ```
 
-Or MSI / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) (stable: `v7.0.4`; beta example: `v7.0.4-beta`). Linux and macOS Inspector builds are zip-only; Windows also ships an MSI. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
+Or MSI / DMG / AppImage / deb / rpm / portable zip from [Download](/download) / [GitHub Releases](https://github.com/justcoding121/titanium-web-proxy/releases) (stable: `v7.0.4`; beta example: `v7.0.4-beta`). **Windows:** MSI (signed). **macOS:** DMG when published (else zip + `install-app.sh`). **Linux glibc:** AppImage / `.deb` / `.rpm` when published. **Alpine musl:** zip only. HTTP/3 natives are bundled the same way as the CLI ([HTTP/3](/docs/http3)).
 
 ## See also
 
 - [Download](/download)
 - [Releases](/releases)
 - [Getting started](/docs/getting-started)
+- [Packaging notes](https://github.com/justcoding121/titanium-web-proxy/blob/develop/tools/packaging/PACKAGING.md)

--- a/website/download.data.ts
+++ b/website/download.data.ts
@@ -17,12 +17,22 @@ export interface DownloadAsset {
 }
 
 export interface ChannelDownloads {
-  /** GitHub release tag, or null when no product zip/MSI release exists for the channel. */
+  /** GitHub release tag, or null when no product zip/MSI/DMG release exists for the channel. */
   tag: string | null
-  cli: Partial<Record<CliRid, DownloadAsset>>
+  cli: Partial<Record<CliRid, DownloadAsset>> & {
+    /** Prefer AppImage / deb / rpm when present (glibc). */
+    appimage?: Partial<Record<'linux-x64' | 'linux-arm64', DownloadAsset>>
+    deb?: Partial<Record<'linux-x64' | 'linux-arm64', DownloadAsset>>
+    rpm?: Partial<Record<'linux-x64' | 'linux-arm64', DownloadAsset>>
+  }
   inspector: {
     msi?: DownloadAsset
     zip?: DownloadAsset
+    /** Prefer DMG when present (macOS). */
+    dmg?: Partial<Record<'osx-x64' | 'osx-arm64', DownloadAsset>>
+    appimage?: Partial<Record<'linux-x64' | 'linux-arm64', DownloadAsset>>
+    deb?: Partial<Record<'linux-x64' | 'linux-arm64', DownloadAsset>>
+    rpm?: Partial<Record<'linux-x64' | 'linux-arm64', DownloadAsset>>
   } & Partial<Record<CliRid, DownloadAsset>>
 }
 
@@ -73,7 +83,9 @@ function hasProductAssets(r: GhRelease): boolean {
     (a) =>
       a.name.startsWith('Titanium.Cli-') ||
       a.name.startsWith('TitaniumInspector-') ||
-      a.name.startsWith('Titanium.Plus-'),
+      a.name.startsWith('Titanium.Plus-') ||
+      a.name.startsWith('titanium-cli') ||
+      a.name.startsWith('titanium-inspector'),
   )
 }
 
@@ -89,13 +101,60 @@ function isBetaRelease(r: GhRelease): boolean {
   )
 }
 
+function ensureNested(
+  out: ChannelDownloads,
+  product: 'cli' | 'inspector',
+  kind: 'appimage' | 'deb' | 'rpm' | 'dmg',
+): Record<string, DownloadAsset> {
+  const bag = out[product] as Record<string, unknown>
+  if (!bag[kind] || typeof bag[kind] !== 'object') bag[kind] = {}
+  return bag[kind] as Record<string, DownloadAsset>
+}
+
 function assignAsset(out: ChannelDownloads, asset: DownloadAsset, name: string): void {
   for (const rid of CLI_RIDS) {
     if (name === `Titanium.Cli-${rid}.zip` && !out.cli[rid]) out.cli[rid] = asset
     if (name === `TitaniumInspector-${rid}.zip` && !out.inspector[rid]) out.inspector[rid] = asset
   }
+
   if (name === 'TitaniumInspector-win-x64.msi' && !out.inspector.msi) out.inspector.msi = asset
   if (name === 'TitaniumInspector-win-x64.zip' && !out.inspector.zip) out.inspector.zip = asset
+
+  // Mac DMG
+  for (const rid of ['osx-arm64', 'osx-x64'] as const) {
+    if (name === `TitaniumInspector-${rid}.dmg`) {
+      const dmg = ensureNested(out, 'inspector', 'dmg')
+      if (!dmg[rid]) dmg[rid] = asset
+    }
+  }
+
+  // Linux AppImage / deb / rpm (glibc only)
+  for (const rid of ['linux-x64', 'linux-arm64'] as const) {
+    if (name === `TitaniumInspector-${rid}.AppImage`) {
+      const m = ensureNested(out, 'inspector', 'appimage')
+      if (!m[rid]) m[rid] = asset
+    }
+    if (name === `Titanium.Cli-${rid}.AppImage`) {
+      const m = ensureNested(out, 'cli', 'appimage')
+      if (!m[rid]) m[rid] = asset
+    }
+    if (name === `TitaniumInspector-${rid}.deb`) {
+      const m = ensureNested(out, 'inspector', 'deb')
+      if (!m[rid]) m[rid] = asset
+    }
+    if (name === `Titanium.Cli-${rid}.deb`) {
+      const m = ensureNested(out, 'cli', 'deb')
+      if (!m[rid]) m[rid] = asset
+    }
+    if (name === `TitaniumInspector-${rid}.rpm`) {
+      const m = ensureNested(out, 'inspector', 'rpm')
+      if (!m[rid]) m[rid] = asset
+    }
+    if (name === `Titanium.Cli-${rid}.rpm`) {
+      const m = ensureNested(out, 'cli', 'rpm')
+      if (!m[rid]) m[rid] = asset
+    }
+  }
 }
 
 function channelFromRelease(r: GhRelease): ChannelDownloads {

--- a/website/download.md
+++ b/website/download.md
@@ -9,11 +9,11 @@ const channels = [
 ]
 </script>
 
-Get CLI and Inspector builds from GitHub Releases. This page lists the **latest stable** and **latest beta** product releases that include zip/MSI assets (NuGet-only tags are skipped).
+Get CLI and Inspector builds from GitHub Releases. This page lists the **latest stable** and **latest beta** product releases (NuGet-only tags are skipped). Prefer the primary format per OS (MSI / DMG / AppImage / deb / rpm); portable zips remain on GitHub for `titanium update` and Alpine/musl.
 
-**winget** installs the last published **stable** community package only — use the buttons below or GitHub for beta.
+**Windows:** Authenticode-signed assets show publisher **Jehonathan Thomas**. **winget** is stable-only. **macOS CLI:** `brew tap justcoding121/titanium && brew install titanium` when the tap is published. **Linux desktop:** Flathub apps are listed after first Flathub acceptance.
 
-HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on Win11 / Server 2022+). Alpine/K8s: use **`linux-musl-*`**, not `linux-x64`. Details: [HTTP/3](/docs/http3).
+HTTP/3 natives ship inside each RID zip / package (except Windows OS MsQuic). Alpine/K8s: use **`linux-musl-*`**, not `linux-x64`. Details: [HTTP/3](/docs/http3).
 
 <div v-for="ch in channels" :key="ch.id" class="download-channel">
   <h2 :id="ch.id">
@@ -23,7 +23,7 @@ HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on
   <p class="vp-muted">
     {{ ch.hint }}
     <template v-if="!ch.data.tag">
-      — no product zip/MSI release on this channel yet; see
+      — no product release on this channel yet; see
       <a :href="links.releasesUrl">GitHub Releases</a>.
     </template>
   </p>
@@ -31,11 +31,10 @@ HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on
   <h3 :id="ch.id + '-inspector'">Titanium Inspector</h3>
   <p>
     Desktop MITM debugger.
-    <strong>Windows:</strong> MSI wizard (choose install folder, Finished + Launch) or portable zip.
-    Uninstall from Settings → Apps (branded icon).
-    <strong>Linux / macOS:</strong> zip — run portable, or use
-    <code>install.sh</code> / <code>install-app.sh</code> in the zip
-    (<code>uninstall.sh</code> / <code>uninstall-app.sh</code> to remove).
+    <strong>Windows:</strong> MSI (signed).
+    <strong>macOS:</strong> DMG when published; otherwise zip + <code>install-app.sh</code>.
+    <strong>Linux glibc:</strong> AppImage / <code>.deb</code> / <code>.rpm</code> when published; otherwise zip.
+    <strong>Alpine musl:</strong> zip only.
   </p>
   <div class="download-grid">
     <div class="download-row">
@@ -44,18 +43,35 @@ HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>Windows zip</strong>
-      <a v-if="ch.data.inspector.zip || ch.data.inspector['win-x64']" :href="(ch.data.inspector.zip || ch.data.inspector['win-x64']).url">{{ (ch.data.inspector.zip || ch.data.inspector['win-x64']).name }}</a>
+      <strong>Linux x64 AppImage</strong>
+      <a v-if="ch.data.inspector.appimage && ch.data.inspector.appimage['linux-x64']" :href="ch.data.inspector.appimage['linux-x64'].url">{{ ch.data.inspector.appimage['linux-x64'].name }}</a>
+      <a v-else-if="ch.data.inspector['linux-x64']" :href="ch.data.inspector['linux-x64'].url">{{ ch.data.inspector['linux-x64'].name }} (zip)</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>Linux x64</strong>
-      <a v-if="ch.data.inspector['linux-x64']" :href="ch.data.inspector['linux-x64'].url">{{ ch.data.inspector['linux-x64'].name }}</a>
+      <strong>Linux x64 .deb</strong>
+      <a v-if="ch.data.inspector.deb && ch.data.inspector.deb['linux-x64']" :href="ch.data.inspector.deb['linux-x64'].url">{{ ch.data.inspector.deb['linux-x64'].name }}</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>Linux arm64</strong>
-      <a v-if="ch.data.inspector['linux-arm64']" :href="ch.data.inspector['linux-arm64'].url">{{ ch.data.inspector['linux-arm64'].name }}</a>
+      <strong>Linux x64 .rpm</strong>
+      <a v-if="ch.data.inspector.rpm && ch.data.inspector.rpm['linux-x64']" :href="ch.data.inspector.rpm['linux-x64'].url">{{ ch.data.inspector.rpm['linux-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 AppImage</strong>
+      <a v-if="ch.data.inspector.appimage && ch.data.inspector.appimage['linux-arm64']" :href="ch.data.inspector.appimage['linux-arm64'].url">{{ ch.data.inspector.appimage['linux-arm64'].name }}</a>
+      <a v-else-if="ch.data.inspector['linux-arm64']" :href="ch.data.inspector['linux-arm64'].url">{{ ch.data.inspector['linux-arm64'].name }} (zip)</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 .deb</strong>
+      <a v-if="ch.data.inspector.deb && ch.data.inspector.deb['linux-arm64']" :href="ch.data.inspector.deb['linux-arm64'].url">{{ ch.data.inspector.deb['linux-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 .rpm</strong>
+      <a v-if="ch.data.inspector.rpm && ch.data.inspector.rpm['linux-arm64']" :href="ch.data.inspector.rpm['linux-arm64'].url">{{ ch.data.inspector.rpm['linux-arm64'].name }}</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
@@ -64,19 +80,29 @@ HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>macOS arm64</strong>
-      <a v-if="ch.data.inspector['osx-arm64']" :href="ch.data.inspector['osx-arm64'].url">{{ ch.data.inspector['osx-arm64'].name }}</a>
+      <strong>Alpine / musl arm64</strong>
+      <a v-if="ch.data.inspector['linux-musl-arm64']" :href="ch.data.inspector['linux-musl-arm64'].url">{{ ch.data.inspector['linux-musl-arm64'].name }}</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>macOS x64</strong>
-      <a v-if="ch.data.inspector['osx-x64']" :href="ch.data.inspector['osx-x64'].url">{{ ch.data.inspector['osx-x64'].name }}</a>
+      <strong>macOS arm64 DMG</strong>
+      <a v-if="ch.data.inspector.dmg && ch.data.inspector.dmg['osx-arm64']" :href="ch.data.inspector.dmg['osx-arm64'].url">{{ ch.data.inspector.dmg['osx-arm64'].name }}</a>
+      <a v-else-if="ch.data.inspector['osx-arm64']" :href="ch.data.inspector['osx-arm64'].url">{{ ch.data.inspector['osx-arm64'].name }} (zip)</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>macOS x64 DMG</strong>
+      <a v-if="ch.data.inspector.dmg && ch.data.inspector.dmg['osx-x64']" :href="ch.data.inspector.dmg['osx-x64'].url">{{ ch.data.inspector.dmg['osx-x64'].name }}</a>
+      <a v-else-if="ch.data.inspector['osx-x64']" :href="ch.data.inspector['osx-x64'].url">{{ ch.data.inspector['osx-x64'].name }} (zip)</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
   </div>
 
   <h3 :id="ch.id + '-cli'">CLI (<code>titanium</code> / <code>twp</code>)</h3>
-  <p>Self-contained zip. Extract and run. Each zip includes both <code>titanium</code> and <code>twp</code> binaries.</p>
+  <p>
+    Each package includes <code>titanium</code> and <code>twp</code>.
+    Prefer AppImage / deb / rpm on Linux glibc; zip on Windows / musl / macOS.
+  </p>
   <div class="download-grid">
     <div class="download-row">
       <strong>Windows x64</strong>
@@ -84,13 +110,35 @@ HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>Linux x64 (glibc)</strong>
-      <a v-if="ch.data.cli['linux-x64']" :href="ch.data.cli['linux-x64'].url">{{ ch.data.cli['linux-x64'].name }}</a>
+      <strong>Linux x64 AppImage</strong>
+      <a v-if="ch.data.cli.appimage && ch.data.cli.appimage['linux-x64']" :href="ch.data.cli.appimage['linux-x64'].url">{{ ch.data.cli.appimage['linux-x64'].name }}</a>
+      <a v-else-if="ch.data.cli['linux-x64']" :href="ch.data.cli['linux-x64'].url">{{ ch.data.cli['linux-x64'].name }} (zip)</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
-      <strong>Linux arm64 (glibc)</strong>
-      <a v-if="ch.data.cli['linux-arm64']" :href="ch.data.cli['linux-arm64'].url">{{ ch.data.cli['linux-arm64'].name }}</a>
+      <strong>Linux x64 .deb</strong>
+      <a v-if="ch.data.cli.deb && ch.data.cli.deb['linux-x64']" :href="ch.data.cli.deb['linux-x64'].url">{{ ch.data.cli.deb['linux-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux x64 .rpm</strong>
+      <a v-if="ch.data.cli.rpm && ch.data.cli.rpm['linux-x64']" :href="ch.data.cli.rpm['linux-x64'].url">{{ ch.data.cli.rpm['linux-x64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 AppImage</strong>
+      <a v-if="ch.data.cli.appimage && ch.data.cli.appimage['linux-arm64']" :href="ch.data.cli.appimage['linux-arm64'].url">{{ ch.data.cli.appimage['linux-arm64'].name }}</a>
+      <a v-else-if="ch.data.cli['linux-arm64']" :href="ch.data.cli['linux-arm64'].url">{{ ch.data.cli['linux-arm64'].name }} (zip)</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 .deb</strong>
+      <a v-if="ch.data.cli.deb && ch.data.cli.deb['linux-arm64']" :href="ch.data.cli.deb['linux-arm64'].url">{{ ch.data.cli.deb['linux-arm64'].name }}</a>
+      <span v-else class="vp-muted">Not published yet</span>
+    </div>
+    <div class="download-row">
+      <strong>Linux arm64 .rpm</strong>
+      <a v-if="ch.data.cli.rpm && ch.data.cli.rpm['linux-arm64']" :href="ch.data.cli.rpm['linux-arm64'].url">{{ ch.data.cli.rpm['linux-arm64'].name }}</a>
       <span v-else class="vp-muted">Not published yet</span>
     </div>
     <div class="download-row">
@@ -122,6 +170,15 @@ HTTP/3 natives ship inside each RID zip (except Windows, which uses OS MsQuic on
 winget install justcoding121.TitaniumCli
 winget install justcoding121.TitaniumInspector
 ```
+
+## Homebrew (macOS CLI)
+
+```shell
+brew tap justcoding121/titanium
+brew install titanium
+```
+
+Requires the public tap repo (`homebrew-titanium`) with formula SHA256s matching the release zip.
 
 ```shell
 titanium run -c twp.yaml


### PR DESCRIPTION
## Summary
Implements Phases 2–3 packaging/trust work from the code-signing plan (agent-side).

- **macOS:** entitlements, `.app` + DMG builders, gated codesign/notarize in `release.yml` (no-ops until Apple secrets exist — see `tools/packaging/osx/APPLE_SECRETS.md`)
- **Linux glibc:** AppImage + deb/rpm for CLI and Inspector; musl stays zip
- **GPG:** always attach `SHA256SUMS`; sign when `GPG_PRIVATE_KEY` set (`GPG_SECRETS.md`)
- **Website:** prefer MSI/DMG/AppImage/deb/rpm; keep zips for `titanium update`
- **Homebrew:** formula + [justcoding121/homebrew-titanium](https://github.com/justcoding121/homebrew-titanium) tap stub
- **Flathub:** manifests + metainfo + `x-checker-data` + submission README
- **Docs:** `install.md` publisher/verify; `PACKAGING.md`; winget follow-up notes (includes `twp.exe` stub — supersedes #1013)

## Out of band (user / later)
- Apple Developer ID + notary secrets in GitHub
- `GPG_PRIVATE_KEY` for signed checksums
- First **signed** stable cut → winget resubmit + Flathub human submission + brew SHA bump

## Test plan
- [ ] CI green on this PR
- [ ] Optional: `workflow_dispatch` release.yml beta after merge to verify Windows signing still works and new artifact names appear (mac notarize skipped without secrets)