### PR TITLE
fix(release): notarize containers, patchelf filter, Azure FIC nguid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,6 @@ tools/packaging/.cache/
 # WiX extension cache from `dotnet wix extension add`
 tools/packaging/wix/.wix/
 
+
+# Local Apple signing material (never commit)
+tools/packaging/osx/.local-signing/

--- a/tools/packaging/bundle-http3-native.ps1
+++ b/tools/packaging/bundle-http3-native.ps1
@@ -256,10 +256,15 @@ function Ensure-SonameLinks([string] $dir) {
 
 function Set-LinuxRpath([string] $dir) {
     $patchelf = Ensure-Patchelf
-    Get-ChildItem -Path $dir -File -Filter "*.so*" | ForEach-Object {
-        $soFile = $_
+    # Do NOT use Filter "*.so*" — PowerShell/Win32 wildcards match ".Sockets" inside
+    # System.Net.Sockets.dll and similar managed assemblies.
+    $soFiles = @(
+        Get-ChildItem -Path $dir -File -Filter "*.so"
+        Get-ChildItem -Path $dir -File | Where-Object { $_.Name -match '\.so\.\d' }
+    ) | Sort-Object -Property FullName -Unique
+    foreach ($soFile in $soFiles) {
         # Skip pure symlinks
-        if ($soFile.Attributes -band [IO.FileAttributes]::ReparsePoint) { return }
+        if ($soFile.Attributes -band [IO.FileAttributes]::ReparsePoint) { continue }
         try {
             Invoke-Native $patchelf @("--set-rpath", "`$ORIGIN", $soFile.FullName)
         }
@@ -268,6 +273,9 @@ function Set-LinuxRpath([string] $dir) {
             Write-Info "patchelf skipped $($soFile.Name): $_"
         }
     }
+    # Caught native failures leave $LASTEXITCODE non-zero; clear so the GHA pwsh step
+    # does not fail the job after a soft-skip.
+    $global:LASTEXITCODE = 0
 }
 
 function Assert-RequiredFiles([string[]] $globs) {
@@ -443,3 +451,5 @@ switch ($ridEntry.mode) {
 }
 
 Write-Info "done"
+# Ensure GitHub Actions pwsh step succeeds even if a soft-skipped native tool left LASTEXITCODE set.
+$global:LASTEXITCODE = 0

--- a/tools/packaging/osx/sign-and-notarize.sh
+++ b/tools/packaging/osx/sign-and-notarize.sh
@@ -47,20 +47,27 @@ else
   exit 1
 fi
 
+# notarytool accepts only zip / pkg / dmg (or a zipped .app). Raw Mach-O binaries are codesigned only.
 if [[ -n "${NOTARY_KEY:-}" && -n "${NOTARY_KEY_ID:-}" && -n "${NOTARY_ISSUER:-}" ]]; then
   KEY_FILE="$(mktemp).p8"
   printf '%s\n' "${NOTARY_KEY}" > "${KEY_FILE}"
-  SUBMIT="${TARGET}"
-  if [[ -d "${TARGET}" ]]; then
+  SUBMIT=""
+  if [[ -d "${TARGET}" && "${TARGET}" == *.app ]]; then
     SUBMIT="$(mktemp -d)/notarize.zip"
     ditto -c -k --keepParent "${TARGET}" "${SUBMIT}"
+  elif [[ -f "${TARGET}" && ( "${TARGET}" == *.zip || "${TARGET}" == *.dmg || "${TARGET}" == *.pkg ) ]]; then
+    SUBMIT="${TARGET}"
+  else
+    echo "codesign-only (not a notarizable container): ${TARGET}"
   fi
-  xcrun notarytool submit "${SUBMIT}" --wait \
-    --key "${KEY_FILE}" --key-id "${NOTARY_KEY_ID}" --issuer "${NOTARY_ISSUER}"
+  if [[ -n "${SUBMIT}" ]]; then
+    xcrun notarytool submit "${SUBMIT}" --wait \
+      --key "${KEY_FILE}" --key-id "${NOTARY_KEY_ID}" --issuer "${NOTARY_ISSUER}"
+    if [[ "${TARGET}" == *.dmg || "${TARGET}" == *.app || -d "${TARGET}" ]]; then
+      xcrun stapler staple "${TARGET}" || true
+    fi
+  fi
   rm -f "${KEY_FILE}"
-  if [[ "${TARGET}" == *.dmg || "${TARGET}" == *.app || -d "${TARGET}" ]]; then
-    xcrun stapler staple "${TARGET}" || true
-  fi
 fi
 
 echo "Signed ${TARGET}"


### PR DESCRIPTION
## Summary
Beta release [33640630634](https://github.com/justcoding121/titanium-web-proxy/actions/runs/33640630634) failed three ways; this PR fixes the two code bugs. Azure FIC for the new GitHub `sub` claim format was added via `az` (not in this PR).

1. **macOS CLI:** `notarytool` only accepts zip/pkg/dmg — script now codesigns raw binaries and notarizes containers only
2. **Linux:** `*.so*` matched `System.Net.Sockets.dll`; also leftover `$LASTEXITCODE` failed the pwsh step after soft-skip
3. **Windows (ops):** added federated credential `github-twp-signing-nguid` for `repo:justcoding121@2637679/titanium-web-proxy@28822114:environment:signing`

## Test plan
- [ ] Merge and re-dispatch `release.yml` channel=beta
- [ ] Confirm win-x64 Azure login + SignTool
- [ ] Confirm osx CLI/Inspector notarize
- [ ] Confirm linux publish completes