### PR TITLE
packaging: beta Flathub/Homebrew dry-run + catalog smoke

### DIFF
--- a/.github/workflows/packaging-catalog-smoke.yml
+++ b/.github/workflows/packaging-catalog-smoke.yml
@@ -1,0 +1,74 @@
+# Validate Flatpak manifests + Homebrew formula against a published release tag.
+# Used for beta dry-run before stable catalog submit.
+name: packaging-catalog-smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'GitHub release tag (e.g. v7.0.4-beta or v7.0.5)'
+        required: true
+        type: string
+      run_flatpak:
+        description: 'Build Flatpak manifests with flatpak-builder'
+        required: true
+        type: boolean
+        default: true
+      run_homebrew:
+        description: 'Smoke brew install from in-repo formula'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  flatpak:
+    if: inputs.run_flatpak
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install flatpak-builder + Freedesktop 24.08
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install -y --user flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+
+      - name: flatpak-builder Inspector
+        run: |
+          set -euo pipefail
+          flatpak-builder --user --force-clean /tmp/ti-inspector-build \
+            tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+
+      - name: flatpak-builder CLI
+        run: |
+          set -euo pipefail
+          flatpak-builder --user --force-clean /tmp/ti-cli-build \
+            tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
+
+  homebrew:
+    if: inputs.run_homebrew
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Smoke brew install --formula
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          FORMULA=tools/packaging/homebrew/titanium.rb
+          test -f "$FORMULA"
+          # Formula version must match tag without leading v (e.g. 7.0.4-beta).
+          EXPECTED="${RELEASE_TAG#v}"
+          grep -q "version \"$EXPECTED\"" "$FORMULA"
+          brew install --formula "$FORMULA"
+          titanium version
+          brew test titanium || brew test --formula "$FORMULA"
+          brew uninstall --formula titanium || true

--- a/tools/packaging/flatpak/README.md
+++ b/tools/packaging/flatpak/README.md
@@ -9,10 +9,22 @@ First listing is a **human Flathub review**. Later stables should be version / U
 | Inspector | `io.github.justcoding121.TitaniumInspector` | [`io.github.justcoding121.TitaniumInspector.yml`](io.github.justcoding121.TitaniumInspector.yml) |
 | CLI | `io.github.justcoding121.TitaniumCli` | [`io.github.justcoding121.TitaniumCli.yml`](io.github.justcoding121.TitaniumCli.yml) |
 
-## First submission checklist
+## Beta dry-run (before stable Flathub submit)
+
+1. Point manifests at a polished **beta** linux-x64 zip + SHA256 (temporary).
+2. Run [`.github/workflows/packaging-catalog-smoke.yml`](../../.github/workflows/packaging-catalog-smoke.yml) (`run_flatpak=true`) or locally:
+
+```shell
+flatpak-builder --user --force-clean /tmp/ti-build \
+  tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+```
+
+3. Do **not** request formal Flathub merge while URLs still point at a `-beta` tag.
+
+## First / formal submission checklist
 
 1. Cut a **signed/stable** GitHub Release that includes `TitaniumInspector-linux-x64.zip` and `Titanium.Cli-linux-x64.zip`.
-2. Fill `sha256:` in both manifests (`REPLACE_AFTER_RELEASE` → real digest). Prefer AppImage source later if Flathub reviewers prefer a single file; zip is fine for first listing.
+2. Retarget `url:` + `sha256:` in both manifests from beta → stable. Prefer AppImage source later if Flathub reviewers prefer a single file; zip is fine for first listing.
 3. Create Flathub account + two new app repos (or one PR per app) under [flathub/flathub](https://github.com/flathub/flathub) following [App Submission](https://docs.flathub.org/docs/for-app-authors/submission).
 4. Copy this directory’s manifests, `.desktop`, and `.metainfo.xml` into each Flathub app repo.
 5. Respond to reviewer sandbox / metainfo feedback (network + display sockets are already declared for Inspector).

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.metainfo.xml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.metainfo.xml
@@ -15,7 +15,7 @@
     <binary>twp</binary>
   </provides>
   <releases>
-    <release version="7.0.4" date="2026-09-01"/>
+    <release version="7.0.4-beta" date="2026-09-02"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
@@ -19,8 +19,9 @@ modules:
       - install -Dm644 io.github.justcoding121.TitaniumCli.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumCli.metainfo.xml
     sources:
       - type: archive
-        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/Titanium.Cli-linux-x64.zip
-        sha256: REPLACE_AFTER_RELEASE
+        # Beta dry-run target; retarget to stable tag + SHA before formal Flathub submit.
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/Titanium.Cli-linux-x64.zip
+        sha256: 414feed19e12a234702483fe506a3ba4273d66e4e57f8aa68d939c8e9d93e20f
         dest: payload
         x-checker-data:
           type: json

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.metainfo.xml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.metainfo.xml
@@ -12,7 +12,7 @@
   </description>
   <launchable type="desktop-id">io.github.justcoding121.TitaniumInspector.desktop</launchable>
   <releases>
-    <release version="7.0.4" date="2026-09-01"/>
+    <release version="7.0.4-beta" date="2026-09-02"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
@@ -31,8 +31,9 @@ modules:
       - install -Dm644 io.github.justcoding121.TitaniumInspector.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumInspector.metainfo.xml
     sources:
       - type: archive
-        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-linux-x64.zip
-        sha256: REPLACE_AFTER_RELEASE
+        # Beta dry-run target; retarget to stable tag + SHA before formal Flathub submit.
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/TitaniumInspector-linux-x64.zip
+        sha256: 1e2040534bc1a48769a7cf6a3e053818bc27742dd02140804e51e12d8ce15d15
         dest: payload
         x-checker-data:
           type: json

--- a/tools/packaging/homebrew/titanium.rb
+++ b/tools/packaging/homebrew/titanium.rb
@@ -10,17 +10,18 @@
 class Titanium < Formula
   desc "Titanium Web Proxy CLI (MITM / reverse proxy)"
   homepage "https://github.com/justcoding121/titanium-web-proxy"
-  version "7.0.4"
+  # Temporarily points at polished beta; retarget to stable 7.0.5 after signed cut.
+  version "7.0.4-beta"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/justcoding121/titanium-web-proxy/releases/download/v#{version}/Titanium.Cli-osx-arm64.zip"
-      sha256 "REPLACE_OSX_ARM64_SHA256"
+      sha256 "82576f82ebdc971c1130a0fe514c6e1b81f56daf7042ee0613119f981163fb22"
     end
     on_intel do
       url "https://github.com/justcoding121/titanium-web-proxy/releases/download/v#{version}/Titanium.Cli-osx-x64.zip"
-      sha256 "REPLACE_OSX_X64_SHA256"
+      sha256 "b2eddf7ff5008c478ee5d491afbb09467e4aa0b629d6aebef03b3ab854c4a42a"
     end
   end
 


### PR DESCRIPTION
## Summary
- Fill Flatpak manifests + metainfo from polished `v7.0.4-beta` linux-x64 zips
- Fill Homebrew formula from beta osx zips (`7.0.4-beta`)
- Add `packaging-catalog-smoke` workflow for flatpak-builder + brew install dry-run

## Gate
Polished beta already has AppImages + `SHA256SUMS.asc`. This unlocks catalog beta tests before `7.0.5`.