### PR TITLE
chore: bump VersionPrefix to 7.0.5

### DIFF
--- a/src/Titanium.Cli/Titanium.Cli.csproj
+++ b/src/Titanium.Cli/Titanium.Cli.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>false</SignAssembly>
-    <VersionPrefix>7.0.4</VersionPrefix>
+    <VersionPrefix>7.0.5</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Titanium Web Proxy CLI (titanium / twp).</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Titanium.Inspector/Titanium.Inspector.csproj
+++ b/src/Titanium.Inspector/Titanium.Inspector.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>false</SignAssembly>
-    <VersionPrefix>7.0.4</VersionPrefix>
+    <VersionPrefix>7.0.5</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Titanium Inspector desktop traffic debugger (PolyForm Noncommercial).</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Titanium.Plus/Titanium.Plus.csproj
+++ b/src/Titanium.Plus/Titanium.Plus.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
-    <VersionPrefix>7.0.4</VersionPrefix>
+    <VersionPrefix>7.0.5</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Titanium Web Proxy Plus advanced features plugin (PolyForm Noncommercial).</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Titanium.Web.Proxy.Abstractions/Titanium.Web.Proxy.Abstractions.csproj
+++ b/src/Titanium.Web.Proxy.Abstractions/Titanium.Web.Proxy.Abstractions.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
-    <VersionPrefix>7.0.4</VersionPrefix>
+    <VersionPrefix>7.0.5</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>Shared contracts for Titanium Web Proxy routing, clusters, middleware, and plugins.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Titanium.Web.Proxy.Configuration/Titanium.Web.Proxy.Configuration.csproj
+++ b/src/Titanium.Web.Proxy.Configuration/Titanium.Web.Proxy.Configuration.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongNameKey.snk</AssemblyOriginatorKeyFile>
-    <VersionPrefix>7.0.4</VersionPrefix>
+    <VersionPrefix>7.0.5</VersionPrefix>
     <Authors>Jehonathan Thomas</Authors>
     <Description>YAML/JSON configuration binding for Titanium Web Proxy CLI and reverse-proxy documents.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
+++ b/src/Titanium.Web.Proxy/Titanium.Web.Proxy.csproj
@@ -13,7 +13,7 @@
     <!-- Keep in sync with the AssemblyVersion/AssemblyFileVersion attributes in
          Properties/AssemblyInfo.cs on every bump - GenerateAssemblyInfo is false below, so the SDK
          does not derive those attributes from this property automatically. -->
-    <VersionPrefix>7.0.4</VersionPrefix>
+    <VersionPrefix>7.0.5</VersionPrefix>
     <!-- The library itself is the canonical implementation of the TWP001 experimental HTTP/3 APIs.
          Suppress the diagnostic internally; consumers will still see it. -->
     <!--


### PR DESCRIPTION
Phase A of post-beta trust ship: bump product versions for signed stable cut after polished beta + Flathub/Homebrew dry-runs.