### PR TITLE
packaging: retarget catalogs to signed v7.0.5

### DIFF
--- a/tools/packaging/WINGET_FOLLOWUP.md
+++ b/tools/packaging/WINGET_FOLLOWUP.md
@@ -1,6 +1,11 @@
 # Winget follow-up
 
-Status (2026-09-02): Signed stable [`v7.0.5`](https://github.com/justcoding121/titanium-web-proxy/releases/tag/v7.0.5) cut with Authenticode MSI + AppImages + `SHA256SUMS.asc`. Resubmit winget from **stable only**.
+Status (2026-09-02): Signed stable [`v7.0.5`](https://github.com/justcoding121/titanium-web-proxy/releases/tag/v7.0.5) cut with Authenticode MSI + AppImages + `SHA256SUMS.asc`.
+
+## Submitted winget PRs
+
+- CLI: https://github.com/microsoft/winget-pkgs/pull/428410
+- Inspector (Authenticode MSI): https://github.com/microsoft/winget-pkgs/pull/428411
 
 ## Do not
 

--- a/tools/packaging/WINGET_FOLLOWUP.md
+++ b/tools/packaging/WINGET_FOLLOWUP.md
@@ -1,14 +1,13 @@
 # Winget follow-up
 
-Status (2026-09-02): `winget search justcoding121.TitaniumCli` / Inspector — **not in catalog**. Prior `microsoft/winget-pkgs` PRs for unsigned `7.0.4` were closed by the MS bot and never landed on master.
+Status (2026-09-02): Signed stable [`v7.0.5`](https://github.com/justcoding121/titanium-web-proxy/releases/tag/v7.0.5) cut with Authenticode MSI + AppImages + `SHA256SUMS.asc`. Resubmit winget from **stable only**.
 
 ## Do not
 
-- Resubmit another unsigned `7.0.4` with the same installer SHA256s.
+- Resubmit unsigned `7.0.4` or any beta tag to `microsoft/winget-pkgs`.
 
-## After first signed stable (`7.0.5+` recommended if binaries change)
+## After signed stable (`7.0.5+`)
 
-1. Merge repo stub so `twp` → `twp.exe` ([`TitaniumCli.yaml`](winget/TitaniumCli.yaml)).
-2. Compute new SHA256 for `Titanium.Cli-win-x64.zip` and `TitaniumInspector-win-x64.msi` (+ zip if submitted).
-3. Open fresh PRs against `microsoft/winget-pkgs` using the stubs under [`winget/`](winget/).
-4. Note Authenticode publisher **Jehonathan Thomas** in PR description if SmartScreen/winget validation asks.
+1. Refresh SHA256s in [`winget/`](winget/) from the release `SHA256SUMS`.
+2. Open fresh PRs against `microsoft/winget-pkgs` (CLI zip portable + Inspector MSI).
+3. Note Authenticode publisher **Jehonathan Thomas** in the PR description.

--- a/tools/packaging/flatpak/README.md
+++ b/tools/packaging/flatpak/README.md
@@ -9,6 +9,11 @@ First listing is a **human Flathub review**. Later stables should be version / U
 | Inspector | `io.github.justcoding121.TitaniumInspector` | [`io.github.justcoding121.TitaniumInspector.yml`](io.github.justcoding121.TitaniumInspector.yml) |
 | CLI | `io.github.justcoding121.TitaniumCli` | [`io.github.justcoding121.TitaniumCli.yml`](io.github.justcoding121.TitaniumCli.yml) |
 
+## Formal Flathub submissions (v7.0.5)
+
+- Inspector: https://github.com/flathub/flathub/pull/10049
+- CLI: https://github.com/flathub/flathub/pull/10050
+
 ## Beta dry-run (before stable Flathub submit)
 
 1. Point manifests at a polished **beta** linux-x64 zip + SHA256 (temporary).

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.metainfo.xml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.metainfo.xml
@@ -15,7 +15,7 @@
     <binary>twp</binary>
   </provides>
   <releases>
-    <release version="7.0.4-beta" date="2026-09-02"/>
+    <release version="7.0.5" date="2026-09-02"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
@@ -19,9 +19,8 @@ modules:
       - install -Dm644 io.github.justcoding121.TitaniumCli.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumCli.metainfo.xml
     sources:
       - type: archive
-        # Beta dry-run target; retarget to stable tag + SHA before formal Flathub submit.
-        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/Titanium.Cli-linux-x64.zip
-        sha256: 414feed19e12a234702483fe506a3ba4273d66e4e57f8aa68d939c8e9d93e20f
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/Titanium.Cli-linux-x64.zip
+        sha256: 421eb7ccd635863f195e1bf47c5e2f817d5e07328a0fdca95150fde3fc7d7e00
         dest: payload
         x-checker-data:
           type: json

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.metainfo.xml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.metainfo.xml
@@ -13,7 +13,7 @@
   <launchable type="desktop-id">io.github.justcoding121.TitaniumInspector.desktop</launchable>
   <icon type="stock">io.github.justcoding121.TitaniumInspector</icon>
   <releases>
-    <release version="7.0.4-beta" date="2026-09-02"/>
+    <release version="7.0.5" date="2026-09-02"/>
   </releases>
   <content_rating type="oars-1.1"/>
 </component>

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
@@ -32,9 +32,8 @@ modules:
       - install -Dm644 io.github.justcoding121.TitaniumInspector.png /app/share/icons/hicolor/256x256/apps/io.github.justcoding121.TitaniumInspector.png
     sources:
       - type: archive
-        # Beta dry-run target; retarget to stable tag + SHA before formal Flathub submit.
-        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4-beta/TitaniumInspector-linux-x64.zip
-        sha256: 1e2040534bc1a48769a7cf6a3e053818bc27742dd02140804e51e12d8ce15d15
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/TitaniumInspector-linux-x64.zip
+        sha256: d4d18a36c7494639266e451869e7beed8fad16a34c49f785eea1b05936741532
         dest: payload
         x-checker-data:
           type: json

--- a/tools/packaging/homebrew/titanium.rb
+++ b/tools/packaging/homebrew/titanium.rb
@@ -10,18 +10,17 @@
 class Titanium < Formula
   desc "Titanium Web Proxy CLI (MITM / reverse proxy)"
   homepage "https://github.com/justcoding121/titanium-web-proxy"
-  # Temporarily points at polished beta; retarget to stable 7.0.5 after signed cut.
-  version "7.0.4-beta"
+  version "7.0.5"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/justcoding121/titanium-web-proxy/releases/download/v#{version}/Titanium.Cli-osx-arm64.zip"
-      sha256 "82576f82ebdc971c1130a0fe514c6e1b81f56daf7042ee0613119f981163fb22"
+      sha256 "0eebb0a3cff372b004496cd44830edfb546670c42fd18d7abf79b56b15ce30e8"
     end
     on_intel do
       url "https://github.com/justcoding121/titanium-web-proxy/releases/download/v#{version}/Titanium.Cli-osx-x64.zip"
-      sha256 "b2eddf7ff5008c478ee5d491afbb09467e4aa0b629d6aebef03b3ab854c4a42a"
+      sha256 "786f97316afedcd82b3c32e66970984f0f084b52a6a4b2a66b1320834f3d5d07"
     end
   end
 
@@ -33,7 +32,7 @@ class Titanium < Formula
   end
 
   test do
-    # Assembly versions are numeric (e.g. 7.0.4.0); formula may be 7.0.4-beta.
+    # Assembly versions are numeric (e.g. 7.0.5.0); formula may be 7.0.5-beta.
     assert_match version.to_s.split("-").first, shell_output("#{bin}/titanium version")
   end
 end

--- a/tools/packaging/winget/TitaniumCli.yaml
+++ b/tools/packaging/winget/TitaniumCli.yaml
@@ -1,8 +1,8 @@
 # justcoding121.TitaniumCli
-# Stub for microsoft/winget-pkgs. Resubmit only after a *signed* stable cut with fresh SHA256.
-# Publisher on Authenticode is "Jehonathan Thomas"; winget Publisher field may stay justcoding121.
+# Submit a PR to microsoft/winget-pkgs after a *signed* stable GitHub Release.
+# Authenticode publisher: Jehonathan Thomas.
 PackageIdentifier: justcoding121.TitaniumCli
-PackageVersion: 7.0.4
+PackageVersion: 7.0.5
 PackageLocale: en-US
 Publisher: justcoding121
 PackageName: Titanium CLI
@@ -17,7 +17,7 @@ Installers:
         PortableCommandAlias: titanium
       - RelativeFilePath: twp.exe
         PortableCommandAlias: twp
-    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/Titanium.Cli-win-x64.zip
-    InstallerSha256: 67fe922f04d4fddd08a3d459459efda9601b2e814bcdaa8c2c40858fa2bf841a
+    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/Titanium.Cli-win-x64.zip
+    InstallerSha256: 8C6D09C7293C9A3D205C64FB00D946A10AFA3379F072FA83A87EEFC4FE9425E2
 ManifestType: singleton
 ManifestVersion: 1.6.0

--- a/tools/packaging/winget/TitaniumInspector.yaml
+++ b/tools/packaging/winget/TitaniumInspector.yaml
@@ -1,9 +1,9 @@
 # justcoding121.TitaniumInspector
 # Submit a PR to https://github.com/microsoft/winget-pkgs after a *signed* GitHub Release with MSI.
-# Authenticode publisher: Jehonathan Thomas. Do not resubmit unsigned 7.0.4 — wait for next signed stable + new SHA256s.
+# Authenticode publisher: Jehonathan Thomas.
 
 PackageIdentifier: justcoding121.TitaniumInspector
-PackageVersion: 7.0.4
+PackageVersion: 7.0.5
 PackageLocale: en-US
 Publisher: justcoding121
 PublisherUrl: https://github.com/justcoding121/titanium-web-proxy
@@ -13,11 +13,11 @@ ShortDescription: Desktop HTTP(S) traffic debugger for Titanium Web Proxy.
 Installers:
   - Architecture: x64
     InstallerType: wix
-    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-win-x64.msi
-    InstallerSha256: 94a19f24226f6d99bccc9abb2604feddf10b6d68bc13d696baac3e7ac2c9decb
+    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/TitaniumInspector-win-x64.msi
+    InstallerSha256: 15179C71A50B7724F55F421025086E0DA798B6A18EC9004FE64F22E04002124E
   - Architecture: x64
     InstallerType: portable
-    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.4/TitaniumInspector-win-x64.zip
-    InstallerSha256: 59c3fd049596233f9985e223e05fb9529d42ce4aff9abd69f759de53e02d3348
+    InstallerUrl: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/TitaniumInspector-win-x64.zip
+    InstallerSha256: 2A5F29234E2DFA4B29552CFB42E0D84E0CBC556C4787072196FD6EB0756AC15B
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Retarget Flatpak + Homebrew + winget stubs to signed stable v7.0.5 after polished beta catalog dry-runs.