### PR TITLE
fix(flatpak): Flathub linter finish-args

### DIFF
--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumCli.yml
@@ -8,7 +8,8 @@ sdk: org.freedesktop.Sdk
 command: titanium
 finish-args:
   - --share=network
-  - --filesystem=home
+  - --filesystem=xdg-config/titanium:create
+  - --filesystem=xdg-data/titanium:create
 modules:
   - name: titanium-cli
     buildsystem: simple

--- a/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
+++ b/tools/packaging/flatpak/io.github.justcoding121.TitaniumInspector.yml
@@ -14,11 +14,11 @@ command: TitaniumInspector
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=x11
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
-  - --filesystem=home
+  - --filesystem=xdg-config/titanium:create
+  - --filesystem=xdg-data/titanium:create
   - --filesystem=xdg-download
 modules:
   - name: titanium-inspector


### PR DESCRIPTION
Align Flatpak manifests with Flathub linter (home FS, x11/wayland). Matching app-id GitHub repos created for TitaniumInspector / TitaniumCli.