### PR TITLE
Fix Mac Intel H3 c=64 cliff vs YARP

### DIFF
--- a/src/Titanium.Web.Proxy/Http3/Http3OriginBridge.Quic.cs
+++ b/src/Titanium.Web.Proxy/Http3/Http3OriginBridge.Quic.cs
@@ -162,9 +162,12 @@ internal static partial class Http3OriginBridge
 
             // QuicStream WriteAsync may buffer; without Flush the peer can see the request hundreds of
             // ms late (observed ~450ms Cloudflare HTML TTFB with inFlight=1 after request "sent").
-            // Always Flush before CompleteWrites on all OS (Darwin skip-Flush A/B regressed Mac÷YARP).
+            // Always Flush on all OS (Darwin skip-Flush A/B regressed Mac÷YARP). When HEADERS/DATA
+            // already packed STREAM+FIN via completeWrites:true, CompleteWrites is a no-op / throw —
+            // only finish the write side if it is still open (body copy path).
             await originStream.FlushAsync(cancellationToken);
-            originStream.CompleteWrites();
+            if (originStream.CanWrite)
+                originStream.CompleteWrites();
             sessionArgs.Timing?.MarkRequestSent();
 
             const int maxInterimResponses = 20;
@@ -601,9 +604,8 @@ internal static partial class Http3OriginBridge
                     // QuicStream WriteAsync may buffer; without Flush the peer can stall forever
                     // under multiplex (GHA Linux/Windows reverse H3→H3 @ c=64: 0 RPS / ~0% CPU).
                     // Darwin A/B skipping Flush (27d2967d) dropped Mac reverse RPS (~5k→~3–4k) and
-                    // worsened H3÷YARP — keep Flush on all OS.
+                    // worsened H3÷YARP — keep Flush on all OS. completeWrites:true already FINs.
                     await originStream.FlushAsync(cancellationToken);
-                    originStream.CompleteWrites();
 
                     // Verbatim origin→client frame copy, or MITM capture when clientStream is null.
                     // Tiny GET: coalesce HEADERS+DATA into one Quic write (origin probe sends both).

--- a/src/Titanium.Web.Proxy/Http3/Http3RequestStream.cs
+++ b/src/Titanium.Web.Proxy/Http3/Http3RequestStream.cs
@@ -440,7 +440,9 @@ internal static class Http3RequestStream
                 qpackContext?.InFlightMinAbsoluteIndex.TryRemove(stream.Id, out _);
 
                 streamState.ResponseClosed = true;
-                stream.CompleteWrites();
+                // SendResponse often already FINed via completeWrites:true; only finish if still open.
+                if (stream.CanWrite)
+                    stream.CompleteWrites();
             }
             catch (Http3ConnectionException ex)
             {
@@ -613,8 +615,10 @@ internal static class Http3RequestStream
                         streamState.ResponseClosed = true;
                         // Match SendResponseAsync / origin bridge: Flush before FIN so Darwin MsQuic
                         // actually emits the verbatim HEADERS(+DATA) frames (skip-Flush was banned).
+                        // Verbatim coalesce may already have FINed via completeWrites:true.
                         await stream.FlushAsync(streamToken);
-                        stream.CompleteWrites();
+                        if (stream.CanWrite)
+                            stream.CompleteWrites();
                         return;
                     }
                     break;
@@ -658,7 +662,10 @@ internal static class Http3RequestStream
 
                 qpackContext?.InFlightMinAbsoluteIndex.TryRemove(stream.Id, out _);
                 streamState.ResponseClosed = true;
-                stream.CompleteWrites();
+                // SendPreencoded / SendResponse often already FIN via completeWrites:true + Flush.
+                // Only CompleteWrites when the write side is still open (streamed body path).
+                if (stream.CanWrite)
+                    stream.CompleteWrites();
             }
             catch (Exception ex) when (ex is QuicException || ex.GetBaseException() is QuicException)
             {
@@ -1060,7 +1067,7 @@ internal static class Http3RequestStream
         var encoded = QpackEncoder.Encode(headers, qpackContext);
         await Http3Frame.WriteAsync(stream, Http3FrameType.Headers, encoded, ct, completeWrites: true);
         await stream.FlushAsync(ct);
-        stream.CompleteWrites();
+        // completeWrites:true already FINed the QuicStream write side.
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Skip redundant `CompleteWrites()` after STREAM+FIN + Darwin-safe `FlushAsync` on H3 client/origin paths.
- Soft-grow `QuicConnectionPool` to up to 4 shared origin QUIC connections when in-flight streams hit SoftGrow=32 (H3→H3 fan-in under scarce cores).

## Test plan
- [x] Unit: `QuicConnectionPoolTests` (share, soft-grow, cap)
- [x] Local cool H3→H1 TLS: RPS(c=64) ≥ RPS(c=32), ≈YARP
- [x] Local cool H3→H3: RPS(c=64) ≥ RPS(c=32) (flat; SoftGrow=16 regressed absolute RPS)
- [ ] GHA `compare-spot` @ `fix/mac-h3-c64-cliff` run 34390832577 (macos-15-intel + Win/Linux)